### PR TITLE
Implement scraping web app

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,82 @@
-// A simple Node.js script to print 'Hello, World!'
-console.log("Hello, World!");
+const express = require('express');
+const axios = require('axios');
+const cheerio = require('cheerio');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Initialize SQLite database
+const db = new sqlite3.Database(path.join(__dirname, 'raw_articles.db'));
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS articles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    description TEXT,
+    time TEXT,
+    link TEXT UNIQUE,
+    image TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+});
+
+// Endpoint to get all articles
+app.get('/articles', (req, res) => {
+  db.all('SELECT id, title, description, time, link FROM articles ORDER BY created_at DESC', [], (err, rows) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Failed to retrieve articles' });
+    }
+    res.json(rows);
+  });
+});
+
+// Scrape endpoint
+app.get('/scrape', async (req, res) => {
+  try {
+    const url = 'https://www.newswire.ca/news-releases/financial-services-latest-news/acquisitions-mergers-and-takeovers-list/?page=1&pagesize=100';
+    const response = await axios.get(url);
+    const $ = cheerio.load(response.data);
+
+    const articles = [];
+    $('div.col-sm-12.card').each((i, el) => {
+      const h3 = $(el).find('h3').first();
+      const time = h3.find('small').text().trim();
+      h3.find('small').remove();
+      const title = h3.text().trim();
+      const description = $(el).find('p').text().trim();
+      const link = $(el).find('a.newsreleaseconsolidatelink').attr('href') || '';
+      const fullLink = link.startsWith('http') ? link : `https://www.newswire.ca${link}`;
+      articles.push({ title, description, time, link: fullLink });
+    });
+
+    const insertPromises = articles.map(a => {
+      return new Promise((resolve, reject) => {
+        db.run(
+          'INSERT OR IGNORE INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, NULL)',
+          [a.title, a.description, a.time, a.link],
+          function (err) {
+            if (err) return reject(err);
+            resolve(this.changes); // 1 if inserted, 0 if ignored
+          }
+        );
+      });
+    });
+
+    const results = await Promise.all(insertPromises);
+    const inserted = results.reduce((acc, cur) => acc + cur, 0);
+    res.json({ inserted });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Scraping failed' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +13,9 @@
   "dependencies": {
     "@types/node": "^22.13.11",
     "xml2js": "^0.6.2",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "express": "^4.19.2",
+    "axios": "^1.6.7",
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>News Scraper</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 8px; }
+    th { background-color: #f5f5f5; }
+  </style>
+</head>
+<body>
+  <h1>News Scraper</h1>
+  <button id="scrapeBtn">Scrape Articles</button>
+  <table>
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Description</th>
+        <th>Time</th>
+        <th>Link</th>
+      </tr>
+    </thead>
+    <tbody id="articlesBody"></tbody>
+  </table>
+<script>
+async function loadArticles() {
+  const res = await fetch('/articles');
+  const articles = await res.json();
+  const tbody = document.getElementById('articlesBody');
+  tbody.innerHTML = '';
+  articles.forEach(a => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${a.title}</td><td>${a.description}</td><td>${a.time}</td>` +
+                   `<td><a href="${a.link}" target="_blank">Link</a></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('scrapeBtn').addEventListener('click', async () => {
+  await fetch('/scrape');
+  loadArticles();
+});
+
+loadArticles();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Express-based web app with scraping endpoint
- create basic frontend to trigger scraping and show saved articles
- use sqlite for persistence
- add axios and cheerio dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683de740ca688331850c855d93a317a9