### PR TITLE
Add scraping sources table

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const PORT = process.env.PORT || 3000;
 
 // Serve static files
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.json());
 
 // Initialize SQLite database
 const db = new sqlite3.Database(path.join(__dirname, 'raw_articles.db'));
@@ -23,6 +24,17 @@ db.serialize(() => {
     image TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    base_url TEXT,
+    article_selector TEXT,
+    title_selector TEXT,
+    description_selector TEXT,
+    time_selector TEXT,
+    link_selector TEXT,
+    image_selector TEXT
+  )`);
 });
 
 // Endpoint to get all articles
@@ -36,41 +48,120 @@ app.get('/articles', (req, res) => {
   });
 });
 
+// Endpoint to get all scraping sources
+app.get('/sources', (req, res) => {
+  db.all('SELECT * FROM sources', [], (err, rows) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Failed to retrieve sources' });
+    }
+    res.json(rows);
+  });
+});
+
+// Endpoint to add a new scraping source
+app.post('/sources', (req, res) => {
+  const {
+    base_url,
+    article_selector,
+    title_selector,
+    description_selector,
+    time_selector,
+    link_selector,
+    image_selector
+  } = req.body;
+
+  const params = [
+    base_url,
+    article_selector,
+    title_selector,
+    description_selector,
+    time_selector,
+    link_selector,
+    image_selector
+  ];
+
+  db.run(
+    `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    params,
+    function (err) {
+      if (err) {
+        console.error(err);
+        return res.status(500).json({ error: 'Failed to add source' });
+      }
+      res.json({ id: this.lastID });
+    }
+  );
+});
+
+async function scrapeSource(source) {
+  const response = await axios.get(source.base_url);
+  const $ = cheerio.load(response.data);
+
+  const articles = [];
+  $(source.article_selector).each((i, el) => {
+    const container = $(el);
+    let time = '';
+    if (source.time_selector) {
+      time = container.find(source.time_selector).text().trim();
+      container.find(source.time_selector).remove();
+    }
+    const title = container.find(source.title_selector).text().trim();
+    const description = source.description_selector
+      ? container.find(source.description_selector).text().trim()
+      : '';
+    let link = source.link_selector
+      ? container.find(source.link_selector).attr('href') || ''
+      : '';
+    if (link && !link.startsWith('http')) {
+      try {
+        link = new URL(link, source.base_url).href;
+      } catch (e) {}
+    }
+    const image = source.image_selector
+      ? container.find(source.image_selector).attr('src') || null
+      : null;
+
+    articles.push({ title, description, time, link, image });
+  });
+
+  return articles;
+}
+
 // Scrape endpoint
 app.get('/scrape', async (req, res) => {
   try {
-    const url = 'https://www.newswire.ca/news-releases/financial-services-latest-news/acquisitions-mergers-and-takeovers-list/?page=1&pagesize=100';
-    const response = await axios.get(url);
-    const $ = cheerio.load(response.data);
-
-    const articles = [];
-    $('div.col-sm-12.card').each((i, el) => {
-      const h3 = $(el).find('h3').first();
-      const time = h3.find('small').text().trim();
-      h3.find('small').remove();
-      const title = h3.text().trim();
-      const description = $(el).find('p').text().trim();
-      const link = $(el).find('a.newsreleaseconsolidatelink').attr('href') || '';
-      const fullLink = link.startsWith('http') ? link : `https://www.newswire.ca${link}`;
-      articles.push({ title, description, time, link: fullLink });
-    });
-
-    const insertPromises = articles.map(a => {
-      return new Promise((resolve, reject) => {
-        db.run(
-          'INSERT OR IGNORE INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, NULL)',
-          [a.title, a.description, a.time, a.link],
-          function (err) {
-            if (err) return reject(err);
-            resolve(this.changes); // 1 if inserted, 0 if ignored
-          }
-        );
+    const sources = await new Promise((resolve, reject) => {
+      db.all('SELECT * FROM sources', [], (err, rows) => {
+        if (err) return reject(err);
+        resolve(rows);
       });
     });
 
-    const results = await Promise.all(insertPromises);
-    const inserted = results.reduce((acc, cur) => acc + cur, 0);
-    res.json({ inserted });
+    let insertedTotal = 0;
+
+    for (const source of sources) {
+      const articles = await scrapeSource(source);
+
+      const insertPromises = articles.map(a => {
+        return new Promise((resolve, reject) => {
+          db.run(
+            'INSERT OR IGNORE INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, ?)',
+            [a.title, a.description, a.time, a.link, a.image],
+            function (err) {
+              if (err) return reject(err);
+              resolve(this.changes); // 1 if inserted, 0 if ignored
+            }
+          );
+        });
+      });
+
+      const results = await Promise.all(insertPromises);
+      insertedTotal += results.reduce((acc, cur) => acc + cur, 0);
+    }
+
+    res.json({ inserted: insertedTotal });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Scraping failed' });


### PR DESCRIPTION
## Summary
- store custom scraping instructions in `sources` table
- expose API endpoints to add and list sources
- scrape all sources instead of one hardcoded site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683debc8b78483319c7db69016031f7e