### PR TITLE
Enable multi-keyword filters & colored filter table

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,9 +332,13 @@ async function runFilters(articleIds, logs) {
 
     for (const filter of filters) {
       if (filter.type === 'keyword') {
-        const kw = (filter.value || '').toLowerCase();
+        const keywords = (filter.value || '')
+          .split(',')
+          .map(k => k.trim().toLowerCase())
+          .filter(Boolean);
         const text = `${article.title || ''} ${article.description || ''}`.toLowerCase();
-        if (kw && text.includes(kw)) {
+        const matched = keywords.some(kw => text.includes(kw));
+        if (matched) {
           await new Promise((resolve, reject) => {
             db.run(
               'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',

--- a/public/index.html
+++ b/public/index.html
@@ -74,10 +74,11 @@
         tbody.innerHTML = '';
         filters.forEach(f => {
           const tr = document.createElement('tr');
+          const cls = colorClasses[f.id % colorClasses.length];
           tr.innerHTML =
-            `<td class="border px-2 py-1">${f.name || ''}</td>` +
-            `<td class="border px-2 py-1">${f.type}</td>` +
-            `<td class="border px-2 py-1">${f.value || ''}</td>`;
+            `<td class="border px-2 py-1 ${cls}">${f.name || ''}</td>` +
+            `<td class="border px-2 py-1 ${cls}">${f.type}</td>` +
+            `<td class="border px-2 py-1 ${cls}">${f.value || ''}</td>`;
           tbody.appendChild(tr);
         });
       }


### PR DESCRIPTION
## Summary
- allow comma-separated keywords in filter logic
- show active filters with the same color as article pills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f0eef4f2c8331837461d84137adc2