### PR TITLE
Enable re-running filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,9 +332,13 @@ async function runFilters(articleIds, logs) {
 
     for (const filter of filters) {
       if (filter.type === 'keyword') {
-        const kw = (filter.value || '').toLowerCase();
+        const keywords = (filter.value || '')
+          .split(',')
+          .map(k => k.trim().toLowerCase())
+          .filter(Boolean);
         const text = `${article.title || ''} ${article.description || ''}`.toLowerCase();
-        if (kw && text.includes(kw)) {
+        const matched = keywords.some(kw => text.includes(kw));
+        if (matched) {
           await new Promise((resolve, reject) => {
             db.run(
               'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',
@@ -447,6 +451,33 @@ app.get('/scrape', async (req, res) => {
     console.error(err);
     logs.push(`Error: ${err.message}`);
     res.status(500).json({ error: 'Scraping failed', logs });
+  }
+});
+
+// Re-run filters for all existing articles
+app.get('/run-filters', async (req, res) => {
+  const logs = [];
+  try {
+    const ids = await new Promise((resolve, reject) => {
+      db.all('SELECT id FROM articles', [], (err, rows) => {
+        if (err) return reject(err);
+        resolve(rows.map(r => r.id));
+      });
+    });
+
+    await new Promise((resolve, reject) => {
+      db.run('DELETE FROM article_filter_matches', err =>
+        err ? reject(err) : resolve()
+      );
+    });
+    logs.push('Cleared previous filter matches');
+
+    await runFilters(ids, logs);
+    res.json({ processed: ids.length, logs });
+  } catch (err) {
+    console.error(err);
+    logs.push(`Error: ${err.message}`);
+    res.status(500).json({ error: 'Failed to run filters', logs });
   }
 });
 

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
     <h1 class="text-2xl font-bold mb-4">News Scraper</h1>
 
     <button id="scrapeBtn" class="bg-blue-500 text-white px-4 py-2 rounded mb-4">Scrape Articles</button>
+    <button id="runFiltersBtn" class="bg-purple-500 text-white px-4 py-2 rounded mb-4 ml-2">Run Filters</button>
     <div id="scrapeResults" class="mb-2 text-sm"></div>
     <pre id="scrapeLog" class="mb-4 p-2 text-xs bg-gray-100 whitespace-pre-wrap"></pre>
 
@@ -74,10 +75,11 @@
         tbody.innerHTML = '';
         filters.forEach(f => {
           const tr = document.createElement('tr');
+          const cls = colorClasses[f.id % colorClasses.length];
           tr.innerHTML =
-            `<td class="border px-2 py-1">${f.name || ''}</td>` +
-            `<td class="border px-2 py-1">${f.type}</td>` +
-            `<td class="border px-2 py-1">${f.value || ''}</td>`;
+            `<td class="border px-2 py-1 ${cls}">${f.name || ''}</td>` +
+            `<td class="border px-2 py-1 ${cls}">${f.type}</td>` +
+            `<td class="border px-2 py-1 ${cls}">${f.value || ''}</td>`;
           tbody.appendChild(tr);
         });
       }
@@ -139,6 +141,19 @@
         log.textContent = (data.logs || []).join('\n');
         loadArticles();
         loadStats();
+      });
+
+      document.getElementById('runFiltersBtn').addEventListener('click', async () => {
+        const log = document.getElementById('scrapeLog');
+        const div = document.getElementById('scrapeResults');
+        log.textContent = '';
+        div.textContent = '';
+
+        const res = await fetch('/run-filters');
+        const data = await res.json();
+        div.textContent = `Processed ${data.processed} articles`;
+        log.textContent = (data.logs || []).join('\n');
+        loadArticles();
       });
 
       loadSources();


### PR DESCRIPTION
## Summary
- add `/run-filters` endpoint that clears previous matches and reapplies current filters to all articles
- expose a new **Run Filters** button on the homepage to trigger the endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f0eef4f2c8331837461d84137adc2