### PR TITLE
Add article enrichment support

### DIFF
--- a/public/enrich.html
+++ b/public/enrich.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Today's M&A Articles</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="p-4">
+    <nav class="mb-4 space-x-4">
+      <a href="/" class="text-blue-600 underline">Home</a>
+      <a href="/manage.html" class="text-blue-600 underline">Manage Sources & Filters</a>
+      <a href="/enrich.html" class="font-semibold">Today's M&A</a>
+    </nav>
+    <h1 class="text-2xl font-bold mb-4">Today's M&A Articles</h1>
+    <table class="table-auto w-full border-collapse">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">#</th>
+          <th class="border px-2 py-1">Title</th>
+          <th class="border px-2 py-1">Actions</th>
+        </tr>
+      </thead>
+      <tbody id="articlesBody"></tbody>
+    </table>
+    <script>
+      function escapeHtml(str) {
+        return str.replace(/[&<>]/g, t => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[t]));
+      }
+
+      function formatBody(text) {
+        const limit = 200;
+        text = text.replace(/\n+/g, '\n');
+        if (text.length <= limit) {
+          return `<div class="text-container"><span class="full">${escapeHtml(text)}</span></div>`;
+        }
+        const preview = escapeHtml(text.slice(0, limit)) + '...';
+        return `<div class="text-container"><span class="preview">${preview}</span><span class="full hidden">${escapeHtml(text)}</span> <a href="#" class="seeMore text-blue-600 underline">See more</a></div>`;
+      }
+
+      function initToggles() {
+        document.querySelectorAll('.seeMore').forEach(link => {
+          link.onclick = e => {
+            e.preventDefault();
+            const container = e.target.closest('.text-container');
+            container.querySelector('.preview').classList.toggle('hidden');
+            container.querySelector('.full').classList.toggle('hidden');
+            e.target.textContent = container.querySelector('.full').classList.contains('hidden') ? 'See more' : 'Hide';
+          };
+        });
+      }
+
+      function initButtons() {
+        document.querySelectorAll('.enrichBtn').forEach(btn => {
+          btn.addEventListener('click', async e => {
+            const id = e.target.getAttribute('data-id');
+            const resp = await fetch(`/articles/${id}/enrich`, { method: 'POST' });
+            const data = await resp.json();
+            if (data.body) {
+              const wrapper = e.target.parentElement.querySelector('.article-body');
+              wrapper.innerHTML = formatBody(data.body);
+              wrapper.classList.remove('hidden');
+              e.target.textContent = 'Refresh Text';
+              initToggles();
+            }
+          });
+        });
+      }
+
+      async function loadArticles() {
+        const res = await fetch('/articles/mna-today');
+        const articles = await res.json();
+        const tbody = document.getElementById('articlesBody');
+        tbody.innerHTML = '';
+        articles.forEach((a, idx) => {
+          const tr = document.createElement('tr');
+          const btnLabel = a.body ? 'Refresh Text' : 'Get Article Text';
+          const bodyHtml = a.body ? formatBody(a.body) : '';
+          const hiddenClass = a.body ? '' : 'hidden';
+          tr.innerHTML =
+            `<td class="border px-2 py-1">${idx + 1}</td>` +
+            `<td class="border px-2 py-1"><a class="text-blue-600 underline" href="${a.link}" target="_blank">${a.title}</a></td>` +
+            `<td class="border px-2 py-1"><button data-id="${a.id}" class="enrichBtn bg-blue-500 text-white px-2 py-1 rounded mr-2">${btnLabel}</button><div class="article-body mt-2 ${hiddenClass}">${bodyHtml}</div></td>`;
+          tbody.appendChild(tr);
+        });
+        initButtons();
+        initToggles();
+      }
+
+      loadArticles();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `body` column to `article_enrichments`
- expose endpoint to fetch today's M&A articles
- add endpoint to scrape article text and store it
- new page `enrich.html` to view today's M&A articles and fetch text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f2f6b2dcc8331bcdcc8acaa6c5891