### PR TITLE
Improve extract-party logging and add tests

### DIFF
--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -1,0 +1,14 @@
+function parseOpenAIResponse(text) {
+  let acquiror = 'N/A';
+  let target = 'N/A';
+  try {
+    const parsed = JSON.parse(text.trim());
+    if (parsed.acquiror) acquiror = parsed.acquiror;
+    if (parsed.target) target = parsed.target;
+  } catch (e) {
+    // ignore parsing errors
+  }
+  return { acquiror, target };
+}
+
+module.exports = { parseOpenAIResponse };

--- a/test/parseOpenAIResponse.test.js
+++ b/test/parseOpenAIResponse.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseOpenAIResponse } = require('../lib/extractParties');
+
+test('parses valid JSON with acquiror and target', () => {
+  const result = parseOpenAIResponse('{"acquiror":"Acme","target":"Foo"}');
+  assert.deepEqual(result, { acquiror: 'Acme', target: 'Foo' });
+});
+
+test('returns N/A for invalid JSON', () => {
+  const result = parseOpenAIResponse('invalid');
+  assert.deepEqual(result, { acquiror: 'N/A', target: 'N/A' });
+});


### PR DESCRIPTION
## Summary
- add helper for parsing OpenAI party extraction JSON
- add verbose logging and response details in `/articles/:id/extract-parties`
- provide unit tests for parsing helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f5315240883319b2a4c5282af35e0