### PR TITLE
Refactor scraper and filters into modules

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,0 +1,50 @@
+// Filter utilities
+async function runFilters(db, articleIds, logs) {
+  if (!articleIds.length) return;
+  const filters = await new Promise((resolve, reject) => {
+    db.all('SELECT * FROM filters WHERE active = 1', [], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+  if (!filters.length) {
+    logs && logs.push('No active filters to run');
+    return;
+  }
+
+  for (const id of articleIds) {
+    const article = await new Promise((resolve, reject) => {
+      db.get('SELECT title, description FROM articles WHERE id = ?', [id], (err, row) => {
+        if (err) return reject(err);
+        resolve(row);
+      });
+    });
+    if (!article) continue;
+
+    for (const filter of filters) {
+      if (filter.type === 'keyword') {
+        const keywords = (filter.value || '')
+          .split(',')
+          .map(k => k.trim().toLowerCase())
+          .filter(Boolean);
+        const text = `${article.title || ''} ${article.description || ''}`.toLowerCase();
+        const matched = keywords.some(kw => text.includes(kw));
+        if (matched) {
+          await new Promise((resolve, reject) => {
+            db.run(
+              'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',
+              [id, filter.id],
+              err => (err ? reject(err) : resolve())
+            );
+          });
+        }
+      } else if (filter.type === 'embedding') {
+        // TODO: implement semantic filtering using embeddings
+      }
+    }
+  }
+  logs && logs.push(`Ran ${filters.length} filters on ${articleIds.length} articles`);
+}
+
+module.exports = { runFilters };

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -1,0 +1,38 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function scrapeSource(source) {
+  const response = await axios.get(source.base_url);
+  const $ = cheerio.load(response.data);
+
+  const articles = [];
+  $(source.article_selector).each((i, el) => {
+    const container = $(el);
+    let time = '';
+    if (source.time_selector) {
+      time = container.find(source.time_selector).text().trim();
+      container.find(source.time_selector).remove();
+    }
+    const title = container.find(source.title_selector).text().trim();
+    const description = source.description_selector
+      ? container.find(source.description_selector).text().trim()
+      : '';
+    let link = source.link_selector
+      ? container.find(source.link_selector).attr('href') || ''
+      : '';
+    if (link && !link.startsWith('http')) {
+      try {
+        link = new URL(link, source.base_url).href;
+      } catch (e) {}
+    }
+    const image = source.image_selector
+      ? container.find(source.image_selector).attr('src') || null
+      : null;
+
+    articles.push({ title, description, time, link, image });
+  });
+
+  return articles;
+}
+
+module.exports = { scrapeSource };


### PR DESCRIPTION
## Summary
- extract `scrapeSource` into `lib/scraper.js`
- extract `runFilters` into `lib/filters.js`
- use these modules from `index.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f639a83d0833196add199c3ddc357