### PR TITLE
Add enrichment pipeline

### DIFF
--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -1,0 +1,44 @@
+const { parseOpenAIResponse, getFirstSentence } = require('../extractParties');
+
+async function extractParties(db, openai, id) {
+  const row = await new Promise((resolve, reject) => {
+    db.get(
+      `SELECT a.title, e.body FROM articles a JOIN article_enrichments e ON a.id = e.article_id WHERE a.id = ?`,
+      [id],
+      (err, r) => {
+        if (err) return reject(err);
+        resolve(r);
+      }
+    );
+  });
+  if (!row || !row.body) {
+    throw new Error('Article text not found');
+  }
+
+  const firstSentence = getFirstSentence(row.body);
+  const titleAndSentence = `${row.title || ''} ${firstSentence}`.trim();
+  const prompt = `Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "${titleAndSentence}"`;
+
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0
+  });
+
+  const output = resp.choices[0].message.content.trim();
+  const { acquiror, target } = parseOpenAIResponse(output);
+
+  await new Promise((resolve, reject) => {
+    db.run(
+      `INSERT INTO article_enrichments (article_id, acquiror, target)
+       VALUES (?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET acquiror = excluded.acquiror, target = excluded.target`,
+      [id, acquiror, target],
+      err => (err ? reject(err) : resolve())
+    );
+  });
+
+  return { firstSentence, prompt, output, acquiror, target };
+}
+
+module.exports = extractParties;

--- a/lib/enrichment/fetchBody.js
+++ b/lib/enrichment/fetchBody.js
@@ -1,0 +1,84 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function fetchBody(db, id) {
+  const article = await new Promise((resolve, reject) => {
+    db.get('SELECT link FROM articles WHERE id = ?', [id], (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+  if (!article) throw new Error('Article not found');
+
+  const sources = await new Promise((resolve, reject) => {
+    db.all('SELECT * FROM sources', [], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+  let bodySelector = null;
+  try {
+    const articleHost = new URL(article.link).hostname;
+    const src = sources.find(s => {
+      try {
+        return new URL(s.base_url).hostname === articleHost;
+      } catch (e) {
+        return false;
+      }
+    });
+    if (src) bodySelector = src.body_selector || null;
+  } catch (e) {}
+
+  const response = await axios.get(article.link);
+  const $ = cheerio.load(response.data);
+
+  const fallbackSelectors = [
+    '#bw-release-story',
+    '.bw-release-story',
+    '#release-body',
+    '[itemprop="articleBody"]',
+    '.article-content',
+    'article'
+  ];
+
+  let container = null;
+  if (bodySelector) {
+    container = $(bodySelector);
+  }
+  if (!container || !container.length) {
+    for (const sel of fallbackSelectors) {
+      const c = $(sel);
+      if (c.length) {
+        container = c;
+        break;
+      }
+    }
+  }
+  if (!container || !container.length) {
+    container = $('body');
+  }
+
+  let text = container
+    .find('p, li')
+    .map((i, el) => $(el).text().trim())
+    .get()
+    .join('\n');
+  if (!text) {
+    text = container.text().trim();
+  }
+
+  await new Promise((resolve, reject) => {
+    db.run(
+      `INSERT INTO article_enrichments (article_id, body)
+       VALUES (?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET body = excluded.body`,
+      [id, text],
+      err => (err ? reject(err) : resolve())
+    );
+  });
+
+  return text;
+}
+
+module.exports = fetchBody;

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -1,0 +1,9 @@
+const fetchBody = require('./fetchBody');
+const extractParties = require('./extractParties');
+
+module.exports = (db, openai) => {
+  return async function processArticle(id) {
+    await fetchBody(db, id);
+    await extractParties(db, openai, id);
+  };
+};


### PR DESCRIPTION
## Summary
- modularize article enrichment steps
- create fetchBody and extractParties helpers
- add pipeline to sequentially run enrichment
- trigger enrichment automatically during scraping
- refactor enrichment endpoints to use new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f639faff083318e4cfba06a95a081