### PR TITLE
Add enrichment unit tests

### DIFF
--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -62,4 +62,21 @@ function getFirstSentence(text) {
   return sentence.trim();
 }
 
-module.exports = { parseOpenAIResponse, getFirstSentence };
+async function extractParties(openai, title, body) {
+  const firstSentence = getFirstSentence(body);
+  const titleAndSentence = `${title || ''} ${firstSentence}`.trim();
+  const prompt =
+    `Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "${titleAndSentence}"`;
+
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0
+  });
+
+  const output = resp.choices[0].message.content.trim();
+  const { acquiror, target } = parseOpenAIResponse(output);
+  return { acquiror, target, prompt, firstSentence, output };
+}
+
+module.exports = { parseOpenAIResponse, getFirstSentence, extractParties };

--- a/lib/fetchBody.js
+++ b/lib/fetchBody.js
@@ -1,0 +1,71 @@
+async function fetchHtml(url, http) {
+  if (http && typeof http.get === 'function') {
+    const resp = await http.get(url);
+    return resp.data;
+  }
+  if (typeof fetch === 'function') {
+    const resp = await fetch(url);
+    return await resp.text();
+  }
+  throw new Error('No HTTP client available');
+}
+
+function stripTags(text) {
+  return text.replace(/<[^>]+>/g, '');
+}
+
+function extractSection(html, selector) {
+  if (!selector) return html;
+  if (selector.startsWith('#')) {
+    const id = selector.slice(1);
+    const regex = new RegExp(`<[^>]*id=["']${id}["'][^>]*>([\s\S]*?)</[^>]+>`);
+    const m = html.match(regex);
+    return m ? m[1] : html;
+  }
+  if (selector.startsWith('.')) {
+    const cls = selector.slice(1);
+    const regex = new RegExp(`<[^>]*class=["'][^"']*${cls}[^"']*["'][^>]*>([\s\S]*?)</[^>]+>`);
+    const m = html.match(regex);
+    return m ? m[1] : html;
+  }
+  const regex = new RegExp(`<${selector}[^>]*>([\s\S]*?)</${selector}>`);
+  const m = html.match(regex);
+  return m ? m[1] : html;
+}
+
+function extractParagraphs(html) {
+  const matches = [...html.matchAll(/<(p|li)[^>]*>([\s\S]*?)<\/\1>/g)];
+  const parts = matches
+    .map(m => stripTags(m[2]).trim())
+    .filter(t => t.length > 0);
+  if (parts.length) return parts.join('\n');
+  return stripTags(html).trim();
+}
+
+async function fetchBody(url, bodySelector = null, http) {
+  const html = await fetchHtml(url, http);
+
+  const fallbackSelectors = [
+    '#bw-release-story',
+    '.bw-release-story',
+    '#release-body',
+    '[itemprop="articleBody"]',
+    '.article-content',
+    'article'
+  ];
+
+  let section = extractSection(html, bodySelector);
+  if (section === html) {
+    for (const sel of fallbackSelectors) {
+      const sec = extractSection(html, sel);
+      if (sec !== html) {
+        section = sec;
+        break;
+      }
+    }
+  }
+
+  return extractParagraphs(section);
+}
+
+module.exports = fetchBody;

--- a/test/enrichment/extractParties.test.js
+++ b/test/enrichment/extractParties.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { extractParties } = require('../../lib/extractParties');
+
+test('extracts acquiror and target using OpenAI output', async () => {
+  const mockOpenAI = {
+    chat: {
+      completions: {
+        create: async () => ({
+          choices: [{ message: { content: '{"acquiror":"Acme","target":"Foo"}' } }]
+        })
+      }
+    }
+  };
+  const body = 'Acme Corp. today announced it will acquire Foo Inc.';
+  const result = await extractParties(mockOpenAI, 'Acme buys Foo', body);
+  assert.equal(result.acquiror, 'Acme');
+  assert.equal(result.target, 'Foo');
+});
+
+test('handles invalid OpenAI JSON', async () => {
+  const mockOpenAI = {
+    chat: {
+      completions: {
+        create: async () => ({ choices: [{ message: { content: 'invalid' } }] })
+      }
+    }
+  };
+  const body = 'No acquisition mentioned.';
+  const result = await extractParties(mockOpenAI, 'Some title', body);
+  assert.equal(result.acquiror, 'N/A');
+  assert.equal(result.target, 'N/A');
+});

--- a/test/enrichment/fetchBody.test.js
+++ b/test/enrichment/fetchBody.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fetchBody = require('../../lib/fetchBody');
+
+test('uses provided selector to extract text', async () => {
+  const html = '<div id="main"><p>First</p><p>Second</p></div>';
+  const mockHttp = { get: async () => ({ data: html }) };
+  const body = await fetchBody('http://example.com', '#main', mockHttp);
+  assert.equal(body, 'First\nSecond');
+});
+
+test('falls back to article tag when selector missing', async () => {
+  const html = '<article><p>Foo</p><p>Bar</p></article>';
+  const mockHttp = { get: async () => ({ data: html }) };
+  const body = await fetchBody('http://example.com', null, mockHttp);
+  assert.equal(body, 'Foo\nBar');
+});


### PR DESCRIPTION
## Summary
- implement a small `fetchBody` helper
- extend `extractParties` module with a function invoking OpenAI
- add tests for article body fetching and party extraction under `test/enrichment`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f63a0a0988331afe83e048f708926