### PR TITLE
Refactor sqlite access

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,33 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.join(__dirname, '..', 'raw_articles.db'));
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+module.exports = { db, run, get, all };


### PR DESCRIPTION
## Summary
- introduce db helper with async wrappers
- use helper for all sqlite access
- drop unused db export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683f638722048331996f5b18a0af58d2