### PR TITLE
Refactor DB access with promise helpers

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,6 +1,39 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 
-const db = new sqlite3.Database(path.join(__dirname, 'raw_articles.db'));
+const connection = new sqlite3.Database(
+  path.join(__dirname, 'raw_articles.db')
+);
 
-module.exports = db;
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    connection.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve({ lastID: this.lastID, changes: this.changes });
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    connection.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    connection.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+function serialize(fn) {
+  connection.serialize(fn);
+}
+
+module.exports = { run, get, all, serialize, raw: connection };

--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -1,16 +1,10 @@
 const { parseOpenAIResponse, getFirstSentence } = require('../extractParties');
 
 async function extractParties(db, openai, id) {
-  const row = await new Promise((resolve, reject) => {
-    db.get(
-      `SELECT a.title, e.body FROM articles a JOIN article_enrichments e ON a.id = e.article_id WHERE a.id = ?`,
-      [id],
-      (err, r) => {
-        if (err) return reject(err);
-        resolve(r);
-      }
-    );
-  });
+  const row = await db.get(
+    `SELECT a.title, e.body FROM articles a JOIN article_enrichments e ON a.id = e.article_id WHERE a.id = ?`,
+    [id]
+  );
   if (!row || !row.body) {
     throw new Error('Article text not found');
   }
@@ -28,15 +22,12 @@ async function extractParties(db, openai, id) {
   const output = resp.choices[0].message.content.trim();
   const { acquiror, target } = parseOpenAIResponse(output);
 
-  await new Promise((resolve, reject) => {
-    db.run(
-      `INSERT INTO article_enrichments (article_id, acquiror, target)
+  await db.run(
+    `INSERT INTO article_enrichments (article_id, acquiror, target)
        VALUES (?, ?, ?)
        ON CONFLICT(article_id) DO UPDATE SET acquiror = excluded.acquiror, target = excluded.target`,
-      [id, acquiror, target],
-      err => (err ? reject(err) : resolve())
-    );
-  });
+    [id, acquiror, target]
+  );
 
   return { firstSentence, prompt, output, acquiror, target };
 }

--- a/lib/enrichment/fetchBody.js
+++ b/lib/enrichment/fetchBody.js
@@ -2,20 +2,10 @@ const axios = require('axios');
 const cheerio = require('cheerio');
 
 async function fetchBody(db, id) {
-  const article = await new Promise((resolve, reject) => {
-    db.get('SELECT link FROM articles WHERE id = ?', [id], (err, row) => {
-      if (err) return reject(err);
-      resolve(row);
-    });
-  });
+  const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
 
-  const sources = await new Promise((resolve, reject) => {
-    db.all('SELECT * FROM sources', [], (err, rows) => {
-      if (err) return reject(err);
-      resolve(rows);
-    });
-  });
+  const sources = await db.all('SELECT * FROM sources');
 
   let bodySelector = null;
   try {
@@ -68,15 +58,12 @@ async function fetchBody(db, id) {
     text = container.text().trim();
   }
 
-  await new Promise((resolve, reject) => {
-    db.run(
-      `INSERT INTO article_enrichments (article_id, body)
+  await db.run(
+    `INSERT INTO article_enrichments (article_id, body)
        VALUES (?, ?)
        ON CONFLICT(article_id) DO UPDATE SET body = excluded.body`,
-      [id, text],
-      err => (err ? reject(err) : resolve())
-    );
-  });
+    [id, text]
+  );
 
   return text;
 }

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,12 +1,7 @@
 // Filter utilities
 async function runFilters(db, articleIds, logs) {
   if (!articleIds.length) return;
-  const filters = await new Promise((resolve, reject) => {
-    db.all('SELECT * FROM filters WHERE active = 1', [], (err, rows) => {
-      if (err) return reject(err);
-      resolve(rows);
-    });
-  });
+  const filters = await db.all('SELECT * FROM filters WHERE active = 1');
 
   if (!filters.length) {
     logs && logs.push('No active filters to run');
@@ -14,12 +9,10 @@ async function runFilters(db, articleIds, logs) {
   }
 
   for (const id of articleIds) {
-    const article = await new Promise((resolve, reject) => {
-      db.get('SELECT title, description FROM articles WHERE id = ?', [id], (err, row) => {
-        if (err) return reject(err);
-        resolve(row);
-      });
-    });
+    const article = await db.get(
+      'SELECT title, description FROM articles WHERE id = ?',
+      [id]
+    );
     if (!article) continue;
 
     for (const filter of filters) {
@@ -31,13 +24,10 @@ async function runFilters(db, articleIds, logs) {
         const text = `${article.title || ''} ${article.description || ''}`.toLowerCase();
         const matched = keywords.some(kw => text.includes(kw));
         if (matched) {
-          await new Promise((resolve, reject) => {
-            db.run(
-              'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',
-              [id, filter.id],
-              err => (err ? reject(err) : resolve())
-            );
-          });
+          await db.run(
+            'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',
+            [id, filter.id]
+          );
         }
       } else if (filter.type === 'embedding') {
         // TODO: implement semantic filtering using embeddings

--- a/routes/filters.js
+++ b/routes/filters.js
@@ -4,59 +4,57 @@ const db = require('../db');
 const router = express.Router();
 
 // Get all filters
-router.get('/', (req, res) => {
-  db.all('SELECT * FROM filters', [], (err, rows) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).json({ error: 'Failed to retrieve filters' });
-    }
+router.get('/', async (req, res) => {
+  try {
+    const rows = await db.all('SELECT * FROM filters');
     res.json(rows);
-  });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve filters' });
+  }
 });
 
 // Add a filter
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   const { name, type, value, active = 1 } = req.body;
-  db.run(
-    'INSERT INTO filters (name, type, value, active) VALUES (?, ?, ?, ?)',
-    [name, type, value, active],
-    function (err) {
-      if (err) {
-        console.error(err);
-        return res.status(500).json({ error: 'Failed to add filter' });
-      }
-      res.json({ id: this.lastID });
-    }
-  );
+  try {
+    const result = await db.run(
+      'INSERT INTO filters (name, type, value, active) VALUES (?, ?, ?, ?)',
+      [name, type, value, active]
+    );
+    res.json({ id: result.lastID });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to add filter' });
+  }
 });
 
 // Update a filter
-router.put('/:id', (req, res) => {
+router.put('/:id', async (req, res) => {
   const { id } = req.params;
   const { name, type, value, active } = req.body;
-  db.run(
-    'UPDATE filters SET name = ?, type = ?, value = ?, active = ? WHERE id = ?',
-    [name, type, value, active, id],
-    function (err) {
-      if (err) {
-        console.error(err);
-        return res.status(500).json({ error: 'Failed to update filter' });
-      }
-      res.json({ updated: this.changes });
-    }
-  );
+  try {
+    const result = await db.run(
+      'UPDATE filters SET name = ?, type = ?, value = ?, active = ? WHERE id = ?',
+      [name, type, value, active, id]
+    );
+    res.json({ updated: result.changes });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to update filter' });
+  }
 });
 
 // Delete a filter
-router.delete('/:id', (req, res) => {
+router.delete('/:id', async (req, res) => {
   const { id } = req.params;
-  db.run('DELETE FROM filters WHERE id = ?', [id], function (err) {
-    if (err) {
-      console.error(err);
-      return res.status(500).json({ error: 'Failed to delete filter' });
-    }
-    res.json({ deleted: this.changes });
-  });
+  try {
+    const result = await db.run('DELETE FROM filters WHERE id = ?', [id]);
+    res.json({ deleted: result.changes });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete filter' });
+  }
 });
 
 module.exports = router;

--- a/routes/sources.js
+++ b/routes/sources.js
@@ -4,18 +4,18 @@ const db = require('../db');
 const router = express.Router();
 
 // Get all scraping sources
-router.get('/', (req, res) => {
-  db.all('SELECT * FROM sources', [], (err, rows) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).json({ error: 'Failed to retrieve sources' });
-    }
+router.get('/', async (req, res) => {
+  try {
+    const rows = await db.all('SELECT * FROM sources');
     res.json(rows);
-  });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve sources' });
+  }
 });
 
 // Add a new scraping source
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   const {
     base_url,
     article_selector,
@@ -38,34 +38,33 @@ router.post('/', (req, res) => {
     body_selector
   ];
 
-  db.run(
-    `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector, body_selector)
+  try {
+    const result = await db.run(
+      `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector, body_selector)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    params,
-    function (err) {
-      if (err) {
-        console.error(err);
-        return res.status(500).json({ error: 'Failed to add source' });
-      }
-      res.json({ id: this.lastID });
-    }
-  );
+      params
+    );
+    res.json({ id: result.lastID });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to add source' });
+  }
 });
 
 // Delete a scraping source
-router.delete('/:id', (req, res) => {
+router.delete('/:id', async (req, res) => {
   const { id } = req.params;
-  db.run('DELETE FROM sources WHERE id = ?', [id], function (err) {
-    if (err) {
-      console.error(err);
-      return res.status(500).json({ error: 'Failed to delete source' });
-    }
-    res.json({ deleted: this.changes });
-  });
+  try {
+    const result = await db.run('DELETE FROM sources WHERE id = ?', [id]);
+    res.json({ deleted: result.changes });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete source' });
+  }
 });
 
 // Update a scraping source
-router.put('/:id', (req, res) => {
+router.put('/:id', async (req, res) => {
   const { id } = req.params;
   const {
     base_url,
@@ -90,17 +89,16 @@ router.put('/:id', (req, res) => {
     id,
   ];
 
-  db.run(
-    `UPDATE sources SET base_url = ?, article_selector = ?, title_selector = ?, description_selector = ?, time_selector = ?, link_selector = ?, image_selector = ?, body_selector = ? WHERE id = ?`,
-    params,
-    function (err) {
-      if (err) {
-        console.error(err);
-        return res.status(500).json({ error: 'Failed to update source' });
-      }
-      res.json({ updated: this.changes });
-    }
-  );
+  try {
+    const result = await db.run(
+      `UPDATE sources SET base_url = ?, article_selector = ?, title_selector = ?, description_selector = ?, time_selector = ?, link_selector = ?, image_selector = ?, body_selector = ? WHERE id = ?`,
+      params
+    );
+    res.json({ updated: result.changes });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to update source' });
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- refactor db.js to export promise-based helpers
- update initialization to use async/await
- replace callback-style SQL in routes and libs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f6a94dbb48331a33b7b66370ceaf9