### PR TITLE
Add editable prompt storage

### DIFF
--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -1,4 +1,9 @@
-const { parseOpenAIResponse, getFirstSentence } = require('../extractParties');
+const {
+  parseOpenAIResponse,
+  getFirstSentence,
+  DEFAULT_TEMPLATE
+} = require('../extractParties');
+const { getPrompt } = require('../prompts');
 
 async function extractParties(db, openai, id) {
   const row = await db.get(
@@ -11,7 +16,8 @@ async function extractParties(db, openai, id) {
 
   const firstSentence = getFirstSentence(row.body);
   const titleAndSentence = `${row.title || ''} ${firstSentence}`.trim();
-  const prompt = `Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "${titleAndSentence}"`;
+  const template = await getPrompt(db, 'extractParties', DEFAULT_TEMPLATE);
+  const prompt = template.replace('{text}', titleAndSentence);
 
   const resp = await openai.chat.completions.create({
     model: 'gpt-3.5-turbo',

--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -62,11 +62,13 @@ function getFirstSentence(text) {
   return sentence.trim();
 }
 
-async function extractParties(openai, title, body) {
+const DEFAULT_TEMPLATE =
+  'Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "{text}"';
+
+async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) {
   const firstSentence = getFirstSentence(body);
   const titleAndSentence = `${title || ''} ${firstSentence}`.trim();
-  const prompt =
-    `Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "${titleAndSentence}"`;
+  const prompt = template.replace('{text}', titleAndSentence);
 
   const resp = await openai.chat.completions.create({
     model: 'gpt-3.5-turbo',
@@ -79,4 +81,9 @@ async function extractParties(openai, title, body) {
   return { acquiror, target, prompt, firstSentence, output };
 }
 
-module.exports = { parseOpenAIResponse, getFirstSentence, extractParties };
+module.exports = {
+  parseOpenAIResponse,
+  getFirstSentence,
+  extractParties,
+  DEFAULT_TEMPLATE
+};

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,0 +1,23 @@
+async function getPrompt(db, name, defaultTemplate) {
+  const row = await db.get('SELECT template FROM prompts WHERE name = ?', [name]);
+  if (row && row.template) return row.template;
+  if (defaultTemplate !== undefined) {
+    await db.run(
+      'INSERT OR IGNORE INTO prompts (name, template) VALUES (?, ?)',
+      [name, defaultTemplate]
+    );
+    return defaultTemplate;
+  }
+  return null;
+}
+
+async function setPrompt(db, name, template) {
+  const result = await db.run(
+    `INSERT INTO prompts (name, template) VALUES (?, ?)
+       ON CONFLICT(name) DO UPDATE SET template = excluded.template`,
+    [name, template]
+  );
+  return result.changes;
+}
+
+module.exports = { getPrompt, setPrompt };

--- a/routes/prompts.js
+++ b/routes/prompts.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const db = require('../db');
+const { getPrompt, setPrompt } = require('../lib/prompts');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const rows = await db.all('SELECT name, template FROM prompts');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve prompts' });
+  }
+});
+
+router.get('/:name', async (req, res) => {
+  const { name } = req.params;
+  try {
+    const template = await getPrompt(db, name);
+    if (!template) return res.status(404).json({ error: 'Prompt not found' });
+    res.json({ name, template });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve prompt' });
+  }
+});
+
+router.put('/:name', async (req, res) => {
+  const { name } = req.params;
+  const { template } = req.body;
+  try {
+    const changes = await setPrompt(db, name, template);
+    res.json({ updated: changes });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to update prompt' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- store enrichment prompt templates in a `prompts` table
- load prompt templates for extracting parties from the database
- export default template in `extractParties` and allow overrides
- expose `/prompts` API endpoints to list, fetch and update templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684054f931d083318cda2def09595a02