### PR TITLE
Add seller field and tracking for enrichments

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,11 +48,13 @@ async function initDb() {
     embedding TEXT,
     is_mna INTEGER,
     acquiror TEXT,
+    seller TEXT,
     target TEXT,
     deal_value TEXT,
     industry TEXT,
     extra TEXT,
     body TEXT,
+    completed TEXT,
     FOREIGN KEY(article_id) REFERENCES articles(id)
   )`);
 
@@ -70,7 +72,7 @@ async function initDb() {
       'INSERT INTO prompts (name, template) VALUES (?, ?)',
       [
         'extractParties',
-        'Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "{text}"'
+        'Extract the acquiror, seller and target from this text. The seller and acquiror may be the same, and the target may be select assets or a division. If none are mentioned, respond with {"acquiror":"N/A","seller":"N/A","target":"N/A"}. Text: "{text}"'
       ]
     );
   }
@@ -79,6 +81,14 @@ async function initDb() {
   const hasBody = aeInfo.some(r => r.name === 'body');
   if (!hasBody) {
     await db.run('ALTER TABLE article_enrichments ADD COLUMN body TEXT');
+  }
+  const hasSeller = aeInfo.some(r => r.name === 'seller');
+  if (!hasSeller) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN seller TEXT');
+  }
+  const hasCompleted = aeInfo.some(r => r.name === 'completed');
+  if (!hasCompleted) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN completed TEXT');
   }
 
   await db.run(`CREATE TABLE IF NOT EXISTS sources (

--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -26,16 +26,24 @@ async function extractParties(db, openai, id) {
   });
 
   const output = resp.choices[0].message.content.trim();
-  const { acquiror, target } = parseOpenAIResponse(output);
+  const { acquiror, seller, target } = parseOpenAIResponse(output);
 
   await db.run(
-    `INSERT INTO article_enrichments (article_id, acquiror, target)
-       VALUES (?, ?, ?)
-       ON CONFLICT(article_id) DO UPDATE SET acquiror = excluded.acquiror, target = excluded.target`,
-    [id, acquiror, target]
+    `INSERT INTO article_enrichments (article_id, acquiror, seller, target)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET acquiror = excluded.acquiror, seller = excluded.seller, target = excluded.target`,
+    [id, acquiror, seller, target]
   );
 
-  return { firstSentence, prompt, output, acquiror, target };
+  const row2 = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
+  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
+  if (!completed.includes('parties')) completed.push('parties');
+  await db.run(
+    `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
+    [completed.join(','), id]
+  );
+
+  return { firstSentence, prompt, output, acquiror, seller, target, completed: completed.join(',') };
 }
 
 module.exports = extractParties;

--- a/lib/enrichment/fetchBody.js
+++ b/lib/enrichment/fetchBody.js
@@ -65,7 +65,15 @@ async function fetchBody(db, id) {
     [id, text]
   );
 
-  return text;
+  const row = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
+  const completed = row && row.completed ? row.completed.split(',') : [];
+  if (!completed.includes('body')) completed.push('body');
+  await db.run(
+    `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
+    [completed.join(','), id]
+  );
+
+  return { body: text, completed: completed.join(',') };
 }
 
 module.exports = fetchBody;

--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -1,14 +1,16 @@
 function parseOpenAIResponse(text) {
   let acquiror = 'N/A';
+  let seller = 'N/A';
   let target = 'N/A';
   try {
     const parsed = JSON.parse(text.trim());
     if (parsed.acquiror) acquiror = parsed.acquiror;
+    if (parsed.seller) seller = parsed.seller;
     if (parsed.target) target = parsed.target;
   } catch (e) {
     // ignore parsing errors
   }
-  return { acquiror, target };
+  return { acquiror, seller, target };
 }
 
 function getFirstSentence(text) {
@@ -63,7 +65,7 @@ function getFirstSentence(text) {
 }
 
 const DEFAULT_TEMPLATE =
-  'Extract the acquiror and target from this text. If none are mentioned, respond with {"acquiror":"N/A","target":"N/A"}. Text: "{text}"';
+  'Extract the acquiror, seller and target from this text. The seller and acquiror may be the same, and the target may be select assets or a division. If none are mentioned, respond with {"acquiror":"N/A","seller":"N/A","target":"N/A"}. Text: "{text}"';
 
 async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) {
   const firstSentence = getFirstSentence(body);
@@ -77,8 +79,8 @@ async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) 
   });
 
   const output = resp.choices[0].message.content.trim();
-  const { acquiror, target } = parseOpenAIResponse(output);
-  return { acquiror, target, prompt, firstSentence, output };
+  const { acquiror, seller, target } = parseOpenAIResponse(output);
+  return { acquiror, seller, target, prompt, firstSentence, output };
 }
 
 module.exports = {

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -36,7 +36,9 @@
           <th class="border px-2 py-1">Title</th>
           <th class="border px-2 py-1">Enrichments</th>
           <th class="border px-2 py-1">Acquiror</th>
+          <th class="border px-2 py-1">Seller</th>
           <th class="border px-2 py-1">Target</th>
+          <th class="border px-2 py-1">Completed</th>
           <th class="border px-2 py-1">Text</th>
         </tr>
       </thead>
@@ -96,6 +98,9 @@
               wrapper.classList.remove('hidden');
               e.target.textContent = 'Refresh Text';
               initToggles();
+              if (data.completed) {
+                e.target.closest('tr').querySelector('.completed-cell').textContent = data.completed;
+              }
               results.textContent = `Fetched ${data.body.length} characters for article ${id}`;
             } else if (data.error) {
               results.textContent = `Error: ${data.error}`;
@@ -127,7 +132,11 @@
             if (data.acquiror !== undefined && data.target !== undefined) {
               const row = e.target.closest('tr');
               row.querySelector('.acquiror-cell').textContent = data.acquiror;
+              row.querySelector('.seller-cell').textContent = data.seller;
               row.querySelector('.target-cell').textContent = data.target;
+              if (data.completed) {
+                row.querySelector('.completed-cell').textContent = data.completed;
+              }
               results.textContent = `Extracted parties for article ${id}`;
             } else if (data.error) {
               results.textContent = `Error: ${data.error}`;
@@ -160,6 +169,9 @@
             wrapper.classList.remove('hidden');
             row.querySelector('.enrichBtn').textContent = 'Refresh Text';
             initToggles();
+            if (data.completed) {
+              row.querySelector('.completed-cell').textContent = data.completed;
+            }
             summary.push(`Article ${id}: ${data.body.length} chars`);
           } else if (data.error) {
             summary.push(`Article ${id}: ${data.error}`);
@@ -187,7 +199,11 @@
           log.textContent = JSON.stringify(data, null, 2);
           if (data.acquiror !== undefined && data.target !== undefined) {
             row.querySelector('.acquiror-cell').textContent = data.acquiror;
+            row.querySelector('.seller-cell').textContent = data.seller;
             row.querySelector('.target-cell').textContent = data.target;
+            if (data.completed) {
+              row.querySelector('.completed-cell').textContent = data.completed;
+            }
             summary.push(`Article ${id}: parties updated`);
           } else if (data.error) {
             summary.push(`Article ${id}: ${data.error}`);
@@ -230,7 +246,9 @@
               `<button disabled class="${disabledCls} px-2 py-1 rounded">Acquirer Info</button>` +
             `</td>` +
             `<td class="border px-2 py-1 acquiror-cell">${a.acquiror || ''}</td>` +
+            `<td class="border px-2 py-1 seller-cell">${a.seller || ''}</td>` +
             `<td class="border px-2 py-1 target-cell">${a.target || ''}</td>` +
+            `<td class="border px-2 py-1 completed-cell">${a.completed || ''}</td>` +
             `<td class="border px-2 py-1"><div class="article-body ${hiddenClass}">${bodyHtml}</div></td>`;
           tbody.appendChild(tr);
         });

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -44,7 +44,7 @@ router.get('/', async (req, res) => {
 router.get('/mna-today', async (req, res) => {
   const query = `
     SELECT a.id, a.title, a.description, a.time, a.link,
-           ae.body, ae.acquiror, ae.target
+           ae.body, ae.acquiror, ae.seller, ae.target, ae.completed
     FROM articles a
     JOIN article_filter_matches m ON a.id = m.article_id
     JOIN filters f ON f.id = m.filter_id
@@ -74,7 +74,7 @@ router.get('/enrich-list', async (req, res) => {
 
   const query = `
     SELECT DISTINCT a.id, a.title, a.description, a.time, a.link,
-           ae.body, ae.acquiror, ae.target
+           ae.body, ae.acquiror, ae.seller, ae.target, ae.completed
     FROM articles a
     ${join}
     LEFT JOIN article_enrichments ae ON a.id = ae.article_id
@@ -94,15 +94,15 @@ router.get('/enrich-list', async (req, res) => {
 router.post('/:id/enrich', async (req, res) => {
   const { id } = req.params;
   try {
-    const text = await fetchBody(db, id);
-    res.json({ success: true, body: text });
+    const result = await fetchBody(db, id);
+    res.json({ success: true, ...result });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to enrich article' });
   }
 });
 
-// Extract acquiror and target using GPT-3.5 from the first sentence
+// Extract acquiror, seller and target using GPT-3.5 from the first sentence
 router.post('/:id/extract-parties', async (req, res) => {
   const { id } = req.params;
   try {

--- a/test/enrichment/extractParties.test.js
+++ b/test/enrichment/extractParties.test.js
@@ -2,12 +2,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { extractParties } = require('../../lib/extractParties');
 
-test('extracts acquiror and target using OpenAI output', async () => {
+test('extracts acquiror, seller and target using OpenAI output', async () => {
   const mockOpenAI = {
     chat: {
       completions: {
         create: async () => ({
-          choices: [{ message: { content: '{"acquiror":"Acme","target":"Foo"}' } }]
+          choices: [{ message: { content: '{"acquiror":"Acme","seller":"SellerCo","target":"Foo"}' } }]
         })
       }
     }
@@ -15,6 +15,7 @@ test('extracts acquiror and target using OpenAI output', async () => {
   const body = 'Acme Corp. today announced it will acquire Foo Inc.';
   const result = await extractParties(mockOpenAI, 'Acme buys Foo', body);
   assert.equal(result.acquiror, 'Acme');
+  assert.equal(result.seller, 'SellerCo');
   assert.equal(result.target, 'Foo');
 });
 
@@ -29,5 +30,6 @@ test('handles invalid OpenAI JSON', async () => {
   const body = 'No acquisition mentioned.';
   const result = await extractParties(mockOpenAI, 'Some title', body);
   assert.equal(result.acquiror, 'N/A');
+  assert.equal(result.seller, 'N/A');
   assert.equal(result.target, 'N/A');
 });

--- a/test/parseOpenAIResponse.test.js
+++ b/test/parseOpenAIResponse.test.js
@@ -2,14 +2,14 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { parseOpenAIResponse, getFirstSentence } = require('../lib/extractParties');
 
-test('parses valid JSON with acquiror and target', () => {
-  const result = parseOpenAIResponse('{"acquiror":"Acme","target":"Foo"}');
-  assert.deepEqual(result, { acquiror: 'Acme', target: 'Foo' });
+test('parses valid JSON with acquiror, seller and target', () => {
+  const result = parseOpenAIResponse('{"acquiror":"Acme","seller":"SellerCo","target":"Foo"}');
+  assert.deepEqual(result, { acquiror: 'Acme', seller: 'SellerCo', target: 'Foo' });
 });
 
 test('returns N/A for invalid JSON', () => {
   const result = parseOpenAIResponse('invalid');
-  assert.deepEqual(result, { acquiror: 'N/A', target: 'N/A' });
+  assert.deepEqual(result, { acquiror: 'N/A', seller: 'N/A', target: 'N/A' });
 });
 
 test('getFirstSentence handles abbreviations', () => {


### PR DESCRIPTION
## Summary
- expand enrichment database table to include `seller` and `completed`
- update default GPT prompt for acquiror, seller and target
- track completed enrichment steps in DB
- expose seller/completed through API and frontend
- adjust tests for new seller field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684058884ad48331832cd3f92c43b1c6