### PR TITLE
Add date/location enrichment

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ async function initDb() {
     deal_value TEXT,
     industry TEXT,
     extra TEXT,
+    article_date TEXT,
+    location TEXT,
     body TEXT,
     completed TEXT,
     FOREIGN KEY(article_id) REFERENCES articles(id)
@@ -89,6 +91,14 @@ async function initDb() {
   const hasCompleted = aeInfo.some(r => r.name === 'completed');
   if (!hasCompleted) {
     await db.run('ALTER TABLE article_enrichments ADD COLUMN completed TEXT');
+  }
+  const hasDate = aeInfo.some(r => r.name === 'article_date');
+  if (!hasDate) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN article_date TEXT');
+  }
+  const hasLocation = aeInfo.some(r => r.name === 'location');
+  if (!hasLocation) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN location TEXT');
   }
 
   await db.run(`CREATE TABLE IF NOT EXISTS sources (

--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -1,0 +1,30 @@
+const extractDateLocation = require('../extractDateLocation');
+
+async function run(db, id) {
+  const row = await db.get(
+    'SELECT body FROM article_enrichments WHERE article_id = ?',
+    [id]
+  );
+  if (!row || !row.body) {
+    throw new Error('Article text not found');
+  }
+  const { date, location } = extractDateLocation(row.body);
+  await db.run(
+    `INSERT INTO article_enrichments (article_id, article_date, location)
+       VALUES (?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET article_date = excluded.article_date, location = excluded.location`,
+    [id, date, location]
+  );
+
+  const row2 = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
+  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
+  if (!completed.includes('dateLocation')) completed.push('dateLocation');
+  await db.run(
+    'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
+    [completed.join(','), id]
+  );
+
+  return { date, location, completed: completed.join(',') };
+}
+
+module.exports = run;

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -1,9 +1,11 @@
 const fetchBody = require('./fetchBody');
+const extractDateLocation = require('./extractDateLocation');
 const extractParties = require('./extractParties');
 
 module.exports = (db, openai) => {
   return async function processArticle(id) {
     await fetchBody(db, id);
+    await extractDateLocation(db, id);
     await extractParties(db, openai, id);
   };
 };

--- a/lib/extractDateLocation.js
+++ b/lib/extractDateLocation.js
@@ -1,0 +1,20 @@
+const { getFirstSentence } = require('./extractParties');
+
+function extractDateLocation(body) {
+  const first = getFirstSentence(body || '');
+  const idx = first.search(/\/CNW|PRNewswire/i);
+  if (idx === -1) {
+    return { date: '', location: '' };
+  }
+  const before = first.slice(0, idx).trim().replace(/[-\s]+$/, '');
+  const dateRegex = /(January|February|March|April|May|June|July|August|September|October|November|December|Jan\.?|Feb\.?|Mar\.?|Apr\.?|Jun\.?|Jul\.?|Aug\.?|Sep\.?|Sept\.?|Oct\.?|Nov\.?|Dec\.?)\s+\d{1,2},\s+\d{4}/i;
+  const m = before.match(dateRegex);
+  if (!m) {
+    return { date: '', location: before.replace(/,[\s]*$/, '') };
+  }
+  const date = m[0].replace(/\s+/g, ' ').trim();
+  const location = before.slice(0, m.index).replace(/,[\s]*$/, '').trim();
+  return { date, location };
+}
+
+module.exports = extractDateLocation;

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -24,6 +24,7 @@
       <button id="loadBtn" class="bg-green-500 text-white px-3 py-1 rounded">Load Articles</button>
       <button id="getAllTextBtn" class="bg-blue-500 text-white px-3 py-1 rounded">Get All Text</button>
       <button id="getAllPartiesBtn" class="bg-purple-500 text-white px-3 py-1 rounded">Get All Parties</button>
+      <button id="getAllDateLocBtn" class="bg-orange-500 text-white px-3 py-1 rounded">Get All Date/Location</button>
     </div>
 
     <div id="actionResults" class="mb-2 text-sm" style="min-height:1.25rem;"></div>
@@ -38,6 +39,8 @@
           <th class="border px-2 py-1">Acquiror</th>
           <th class="border px-2 py-1">Seller</th>
           <th class="border px-2 py-1">Target</th>
+          <th class="border px-2 py-1">Location</th>
+          <th class="border px-2 py-1">Date</th>
           <th class="border px-2 py-1">Completed</th>
           <th class="border px-2 py-1">Text</th>
         </tr>
@@ -102,6 +105,37 @@
                 e.target.closest('tr').querySelector('.completed-cell').textContent = data.completed;
               }
               results.textContent = `Fetched ${data.body.length} characters for article ${id}`;
+            } else if (data.error) {
+              results.textContent = `Error: ${data.error}`;
+            }
+            log.textContent = JSON.stringify(data, null, 2);
+          });
+        });
+
+        document.querySelectorAll('.extractDateBtn').forEach(btn => {
+          btn.addEventListener('click', async e => {
+            const id = e.target.getAttribute('data-id');
+            const log = document.getElementById('actionLog');
+            const results = document.getElementById('actionResults');
+            log.textContent = '';
+            results.textContent = '';
+            let data;
+            try {
+              const resp = await fetch(`/articles/${id}/extract-date-location`, { method: 'POST' });
+              data = await resp.json();
+            } catch (err) {
+              console.error('Extract request failed', err);
+              results.textContent = 'Request failed';
+              return;
+            }
+            if (data.date !== undefined && data.location !== undefined) {
+              const row = e.target.closest('tr');
+              row.querySelector('.date-cell').textContent = data.date;
+              row.querySelector('.location-cell').textContent = data.location;
+              if (data.completed) {
+                row.querySelector('.completed-cell').textContent = data.completed;
+              }
+              results.textContent = `Extracted date/location for article ${id}`;
             } else if (data.error) {
               results.textContent = `Error: ${data.error}`;
             }
@@ -212,6 +246,37 @@
         results.textContent = summary.join('; ');
       }
 
+      async function extractAllDateLoc() {
+        const rows = Array.from(document.querySelectorAll('#articlesBody tr'));
+        const log = document.getElementById('actionLog');
+        const results = document.getElementById('actionResults');
+        log.textContent = '';
+        results.textContent = '';
+        const summary = [];
+        for (const row of rows) {
+          const id = row.querySelector('.extractDateBtn').getAttribute('data-id');
+          let data;
+          try {
+            const resp = await fetch(`/articles/${id}/extract-date-location`, { method: 'POST' });
+            data = await resp.json();
+          } catch (err) {
+            data = { error: 'Request failed' };
+          }
+          log.textContent = JSON.stringify(data, null, 2);
+          if (data.date !== undefined && data.location !== undefined) {
+            row.querySelector('.date-cell').textContent = data.date;
+            row.querySelector('.location-cell').textContent = data.location;
+            if (data.completed) {
+              row.querySelector('.completed-cell').textContent = data.completed;
+            }
+            summary.push(`Article ${id}: date/location updated`);
+          } else if (data.error) {
+            summary.push(`Article ${id}: ${data.error}`);
+          }
+        }
+        results.textContent = summary.join('; ');
+      }
+
       async function loadArticles() {
         const limit = document.getElementById('limitSelect').value;
         const matched = document.getElementById('matchedOnly').checked;
@@ -240,6 +305,7 @@
             `<td class="border px-2 py-1"><a class="text-blue-600 underline" href="${a.link}" target="_blank">${a.title}</a></td>` +
             `<td class="border px-2 py-1 space-x-1">` +
               `<button data-id="${a.id}" class="enrichBtn bg-blue-500 text-white px-2 py-1 rounded">${btnLabel}</button>` +
+              `<button data-id="${a.id}" class="extractDateBtn bg-orange-500 text-white px-2 py-1 rounded">Date/Loc</button>` +
               `<button data-id="${a.id}" class="extractBtn bg-purple-500 text-white px-2 py-1 rounded">Extract Parties</button>` +
               `<button disabled class="${disabledCls} px-2 py-1 rounded">Deal Value</button>` +
               `<button disabled class="${disabledCls} px-2 py-1 rounded">Target Info</button>` +
@@ -248,6 +314,8 @@
             `<td class="border px-2 py-1 acquiror-cell">${a.acquiror || ''}</td>` +
             `<td class="border px-2 py-1 seller-cell">${a.seller || ''}</td>` +
             `<td class="border px-2 py-1 target-cell">${a.target || ''}</td>` +
+            `<td class="border px-2 py-1 location-cell">${a.location || ''}</td>` +
+            `<td class="border px-2 py-1 date-cell">${a.article_date || ''}</td>` +
             `<td class="border px-2 py-1 completed-cell">${a.completed || ''}</td>` +
             `<td class="border px-2 py-1"><div class="article-body ${hiddenClass}">${bodyHtml}</div></td>`;
           tbody.appendChild(tr);
@@ -260,6 +328,7 @@
       document.getElementById('loadBtn').addEventListener('click', loadArticles);
       document.getElementById('getAllTextBtn').addEventListener('click', fetchAllBodies);
       document.getElementById('getAllPartiesBtn').addEventListener('click', extractAllParties);
+      document.getElementById('getAllDateLocBtn').addEventListener('click', extractAllDateLoc);
     </script>
   </body>
 </html>

--- a/test/extractDateLocation.test.js
+++ b/test/extractDateLocation.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const extractDateLocation = require('../lib/extractDateLocation');
+
+test('extracts date and location from CNW style sentence', () => {
+  const text = 'EDMONTON, AB, May 20, 2025 /CNW/ - Maverick acquires Maxcraft.';
+  const res = extractDateLocation(text);
+  assert.equal(res.date, 'May 20, 2025');
+  assert.equal(res.location, 'EDMONTON, AB');
+});
+
+test('returns empty strings when pattern missing', () => {
+  const res = extractDateLocation('No date or location here.');
+  assert.equal(res.date, '');
+  assert.equal(res.location, '');
+});


### PR DESCRIPTION
## Summary
- extract article date and location from first sentence with regex
- store date and location in the article_enrichments table
- expose extraction route for date and location
- show and retrieve date/location details in Enrich UI
- include date/location in enrichment pipeline
- add tests for date/location parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684062b0897c8331a75255f07fb4b1d1