### PR TITLE
Enable source-specific date and location selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,9 @@ async function initDb() {
     time_selector TEXT,
     link_selector TEXT,
     image_selector TEXT,
-    body_selector TEXT
+    body_selector TEXT,
+    location_selector TEXT,
+    date_selector TEXT
   )`);
 
   const srcInfo = await db.all('PRAGMA table_info(sources)');
@@ -123,13 +125,22 @@ async function initDb() {
   if (!hasBodySel) {
     await db.run('ALTER TABLE sources ADD COLUMN body_selector TEXT');
   }
+  const hasLocationSel = srcInfo.some(r => r.name === 'location_selector');
+  if (!hasLocationSel) {
+    await db.run('ALTER TABLE sources ADD COLUMN location_selector TEXT');
+  }
+  const hasDateSel = srcInfo.some(r => r.name === 'date_selector');
+  if (!hasDateSel) {
+    await db.run('ALTER TABLE sources ADD COLUMN date_selector TEXT');
+  }
 
   const row = await db.get('SELECT COUNT(*) as count FROM sources');
   if (row.count === 0) {
     const insert = `INSERT INTO sources
         (base_url, article_selector, title_selector, description_selector,
-         time_selector, link_selector, image_selector, body_selector)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+         time_selector, link_selector, image_selector, body_selector,
+         location_selector, date_selector)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
     await db.run(insert, [
       'https://www.newswire.ca/news-releases/financial-services-latest-news/acquisitions-mergers-and-takeovers-list/?page=1&pagesize=100',
       'div.col-sm-12.card',
@@ -138,7 +149,9 @@ async function initDb() {
       'h3 small',
       'a.newsreleaseconsolidatelink',
       null,
-      '#release-body'
+      '#release-body',
+      'span.xn-location',
+      'span.xn-chron'
     ]);
   }
 }

--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -1,6 +1,46 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
 const extractDateLocation = require('../extractDateLocation');
 
 async function run(db, id) {
+  const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
+  if (!article) throw new Error('Article not found');
+
+  const sources = await db.all('SELECT * FROM sources');
+
+  let dateSelector = null;
+  let locationSelector = null;
+  try {
+    const host = new URL(article.link).hostname;
+    const src = sources.find(s => {
+      try {
+        return new URL(s.base_url).hostname === host;
+      } catch (e) {
+        return false;
+      }
+    });
+    if (src) {
+      dateSelector = src.date_selector || null;
+      locationSelector = src.location_selector || null;
+    }
+  } catch (e) {}
+
+  let date = '';
+  let location = '';
+
+  if (dateSelector || locationSelector) {
+    try {
+      const resp = await axios.get(article.link);
+      const $ = cheerio.load(resp.data);
+      if (dateSelector) {
+        date = $(dateSelector).first().text().trim();
+      }
+      if (locationSelector) {
+        location = $(locationSelector).first().text().trim();
+      }
+    } catch (e) {}
+  }
+
   const row = await db.get(
     'SELECT body FROM article_enrichments WHERE article_id = ?',
     [id]
@@ -8,7 +48,11 @@ async function run(db, id) {
   if (!row || !row.body) {
     throw new Error('Article text not found');
   }
-  const { date, location } = extractDateLocation(row.body);
+  if (!date || !location) {
+    const fallback = extractDateLocation(row.body);
+    if (!date) date = fallback.date;
+    if (!location) location = fallback.location;
+  }
   await db.run(
     `INSERT INTO article_enrichments (article_id, article_date, location)
        VALUES (?, ?, ?)

--- a/public/manage.html
+++ b/public/manage.html
@@ -23,6 +23,8 @@
       <input id="link_selector" class="border px-2 py-1 mr-2" placeholder="Link Selector" />
       <input id="image_selector" class="border px-2 py-1 mr-2" placeholder="Image Selector" />
       <input id="body_selector" class="border px-2 py-1 mr-2" placeholder="Body Selector" />
+      <input id="location_selector" class="border px-2 py-1 mr-2" placeholder="Location Selector" />
+      <input id="date_selector" class="border px-2 py-1 mr-2" placeholder="Date Selector" />
       <button type="submit" class="bg-green-500 text-white px-2 py-1 rounded">Add</button>
     </form>
 
@@ -37,6 +39,8 @@
           <th class="border px-2 py-1">Link Selector</th>
           <th class="border px-2 py-1">Image Selector</th>
           <th class="border px-2 py-1">Body Selector</th>
+          <th class="border px-2 py-1">Location Selector</th>
+          <th class="border px-2 py-1">Date Selector</th>
           <th class="border px-2 py-1">Actions</th>
         </tr>
       </thead>
@@ -94,6 +98,8 @@
            `<td contenteditable="true" class="border px-2 py-1">${s.link_selector || ''}</td>` +
            `<td contenteditable="true" class="border px-2 py-1">${s.image_selector || ''}</td>` +
            `<td contenteditable="true" class="border px-2 py-1">${s.body_selector || ''}</td>` +
+           `<td contenteditable="true" class="border px-2 py-1">${s.location_selector || ''}</td>` +
+           `<td contenteditable="true" class="border px-2 py-1">${s.date_selector || ''}</td>` +
            `<td class="border px-2 py-1">` +
             `<button data-id="${s.id}" class="saveSource bg-blue-500 text-white px-2 py-1 rounded mr-2">Save</button>` +
             `<button data-id="${s.id}" class="deleteSource bg-red-500 text-white px-2 py-1 rounded">Delete</button>` +
@@ -122,7 +128,9 @@
               time_selector: cells[4].innerText.trim(),
               link_selector: cells[5].innerText.trim(),
               image_selector: cells[6].innerText.trim(),
-              body_selector: cells[7].innerText.trim()
+              body_selector: cells[7].innerText.trim(),
+              location_selector: cells[8].innerText.trim(),
+              date_selector: cells[9].innerText.trim()
             };
             await fetch(`/sources/${id}`, {
               method: 'PUT',
@@ -193,7 +201,9 @@
           time_selector: document.getElementById('time_selector').value,
           link_selector: document.getElementById('link_selector').value,
           image_selector: document.getElementById('image_selector').value,
-          body_selector: document.getElementById('body_selector').value
+          body_selector: document.getElementById('body_selector').value,
+          location_selector: document.getElementById('location_selector').value,
+          date_selector: document.getElementById('date_selector').value
         };
         await fetch('/sources', {
           method: 'POST',

--- a/routes/sources.js
+++ b/routes/sources.js
@@ -24,7 +24,9 @@ router.post('/', async (req, res) => {
     time_selector,
     link_selector,
     image_selector,
-    body_selector
+    body_selector,
+    location_selector,
+    date_selector
   } = req.body;
 
   const params = [
@@ -35,13 +37,15 @@ router.post('/', async (req, res) => {
     time_selector,
     link_selector,
     image_selector,
-    body_selector
+    body_selector,
+    location_selector,
+    date_selector
   ];
 
   try {
     const result = await db.run(
-      `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector, body_selector)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector, body_selector, location_selector, date_selector)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       params
     );
     res.json({ id: result.lastID });
@@ -75,6 +79,8 @@ router.put('/:id', async (req, res) => {
     link_selector,
     image_selector,
     body_selector,
+    location_selector,
+    date_selector,
   } = req.body;
 
   const params = [
@@ -86,12 +92,14 @@ router.put('/:id', async (req, res) => {
     link_selector,
     image_selector,
     body_selector,
+    location_selector,
+    date_selector,
     id,
   ];
 
   try {
     const result = await db.run(
-      `UPDATE sources SET base_url = ?, article_selector = ?, title_selector = ?, description_selector = ?, time_selector = ?, link_selector = ?, image_selector = ?, body_selector = ? WHERE id = ?`,
+      `UPDATE sources SET base_url = ?, article_selector = ?, title_selector = ?, description_selector = ?, time_selector = ?, link_selector = ?, image_selector = ?, body_selector = ?, location_selector = ?, date_selector = ? WHERE id = ?`,
       params
     );
     res.json({ updated: result.changes });


### PR DESCRIPTION
## Summary
- store optional `location_selector` and `date_selector` in `sources` table
- expose new fields in source API routes and manage page
- extract article date and location using selectors when available
- default Newswire source now uses `span.xn-location` and `span.xn-chron`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684069ad53bc8331ae5719cd59452a0b