### PR TITLE
Update enrichment prompts and location parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ async function initDb() {
       'INSERT INTO prompts (name, template) VALUES (?, ?)',
       [
         'extractParties',
-        'Extract the acquiror, seller, target and classify whether the article is about "M&A", "Financing" or "Other". Respond with JSON {"acquiror":"N/A","seller":"N/A","target":"N/A","transaction_type":"Other"}. Text: "{text}"'
+        'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Respond with JSON {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}. Text: "{text}"'
       ]
     );
   }

--- a/lib/extractDateLocation.js
+++ b/lib/extractDateLocation.js
@@ -7,13 +7,19 @@ function extractDateLocation(body) {
     return { date: '', location: '' };
   }
   const before = first.slice(0, idx).trim().replace(/[-\s]+$/, '');
-  const dateRegex = /(January|February|March|April|May|June|July|August|September|October|November|December|Jan\.?|Feb\.?|Mar\.?|Apr\.?|Jun\.?|Jul\.?|Aug\.?|Sep\.?|Sept\.?|Oct\.?|Nov\.?|Dec\.?)\s+\d{1,2},\s+\d{4}/i;
-  const m = before.match(dateRegex);
+  const dateRegex = /(January|February|March|April|May|June|July|August|September|October|November|December|Jan\.?|Feb\.?|Mar\.?|Apr\.?|Jun\.?|Jul\.?|Aug\.?|Sep\.?|Sept\.?|Oct\.?|Nov\.?|Dec\.?)\s+\d{1,2},\s+\d{4}/gi;
+  const matches = Array.from(before.matchAll(dateRegex));
+  const m = matches.length ? matches[matches.length - 1] : null;
   if (!m) {
     return { date: '', location: before.replace(/,[\s]*$/, '') };
   }
   const date = m[0].replace(/\s+/g, ' ').trim();
-  const location = before.slice(0, m.index).replace(/,[\s]*$/, '').trim();
+  let location = before.slice(0, m.index).replace(/,[\s]*$/, '').trim();
+  location = location.replace(dateRegex, '').trim();
+  location = location.replace(/^[,\s]+/, '').trim();
+  location = location.replace(/^\d{1,2}:\d{2}\s*(?:AM|PM)?\s*ET\s*/i, '').trim();
+  location = location.replace(/Share this article/i, '').trim();
+  location = location.replace(/^[,\s]+/, '').trim();
   return { date, location };
 }
 

--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -73,7 +73,7 @@ function getFirstSentence(text) {
 }
 
 const DEFAULT_TEMPLATE =
-  'Extract the acquiror, seller, target and classify whether the article is about "M&A", "Financing" or "Other". Respond with JSON in the form {"acquiror":"N/A","seller":"N/A","target":"N/A","transaction_type":"Other"}. Text: "{text}"';
+  'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Respond with JSON in the form {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}. Text: "{text}"';
 
 async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) {
   const firstSentence = getFirstSentence(body);

--- a/public/enrich.html
+++ b/public/enrich.html
@@ -23,7 +23,7 @@
       </select>
       <button id="loadBtn" class="bg-green-500 text-white px-3 py-1 rounded">Load Articles</button>
       <button id="getAllTextBtn" class="bg-blue-500 text-white px-3 py-1 rounded">Get All Text</button>
-      <button id="getAllPartiesBtn" class="bg-purple-500 text-white px-3 py-1 rounded">Get All Parties</button>
+      <button id="getAllPartiesBtn" class="bg-purple-500 text-white px-3 py-1 rounded">Extract Parties &amp; Type</button>
       <button id="getAllDateLocBtn" class="bg-orange-500 text-white px-3 py-1 rounded">Get All Date/Location</button>
     </div>
 
@@ -39,9 +39,9 @@
           <th class="border px-2 py-1">Acquiror</th>
           <th class="border px-2 py-1">Seller</th>
           <th class="border px-2 py-1">Target</th>
+          <th class="border px-2 py-1">Type</th>
           <th class="border px-2 py-1">Location</th>
           <th class="border px-2 py-1">Date</th>
-          <th class="border px-2 py-1">Type</th>
           <th class="border px-2 py-1">Completed</th>
           <th class="border px-2 py-1">Text</th>
         </tr>
@@ -151,7 +151,7 @@
             const results = document.getElementById('actionResults');
             log.textContent = '';
             results.textContent = '';
-            console.log('Extracting parties', id);
+            console.log('Extracting parties and type', id);
 
             let data;
             try {
@@ -169,10 +169,11 @@
               row.querySelector('.acquiror-cell').textContent = data.acquiror;
               row.querySelector('.seller-cell').textContent = data.seller;
               row.querySelector('.target-cell').textContent = data.target;
+              row.querySelector('.type-cell').textContent = data.transactionType;
               if (data.completed) {
                 row.querySelector('.completed-cell').textContent = data.completed;
               }
-              results.textContent = `Extracted parties for article ${id}`;
+              results.textContent = `Extracted parties/type for article ${id}`;
             } else if (data.error) {
               results.textContent = `Error: ${data.error}`;
             }
@@ -237,10 +238,11 @@
             row.querySelector('.acquiror-cell').textContent = data.acquiror;
             row.querySelector('.seller-cell').textContent = data.seller;
             row.querySelector('.target-cell').textContent = data.target;
+            row.querySelector('.type-cell').textContent = data.transactionType;
             if (data.completed) {
               row.querySelector('.completed-cell').textContent = data.completed;
             }
-            summary.push(`Article ${id}: parties updated`);
+            summary.push(`Article ${id}: parties/type updated`);
           } else if (data.error) {
             summary.push(`Article ${id}: ${data.error}`);
           }
@@ -309,7 +311,7 @@
             `<td class="border px-2 py-1 space-x-1">` +
               `<button data-id="${a.id}" class="enrichBtn bg-blue-500 text-white px-2 py-1 rounded">${btnLabel}</button>` +
               `<button data-id="${a.id}" class="extractDateBtn bg-orange-500 text-white px-2 py-1 rounded">Date/Loc</button>` +
-              `<button data-id="${a.id}" class="extractBtn bg-purple-500 text-white px-2 py-1 rounded">Extract Parties</button>` +
+              `<button data-id="${a.id}" class="extractBtn bg-purple-500 text-white px-2 py-1 rounded">Extract Parties &amp; Type</button>` +
               `<button disabled class="${disabledCls} px-2 py-1 rounded">Deal Value</button>` +
               `<button disabled class="${disabledCls} px-2 py-1 rounded">Target Info</button>` +
               `<button disabled class="${disabledCls} px-2 py-1 rounded">Acquirer Info</button>` +
@@ -317,9 +319,9 @@
             `<td class="border px-2 py-1 acquiror-cell">${a.acquiror || ''}</td>` +
             `<td class="border px-2 py-1 seller-cell">${a.seller || ''}</td>` +
             `<td class="border px-2 py-1 target-cell">${a.target || ''}</td>` +
+            `<td class="border px-2 py-1 type-cell">${a.transaction_type || ''}</td>` +
             `<td class="border px-2 py-1 location-cell">${a.location || ''}</td>` +
             `<td class="border px-2 py-1 date-cell">${a.article_date || ''}</td>` +
-            `<td class="border px-2 py-1 type-cell">${a.transaction_type || ''}</td>` +
             `<td class="border px-2 py-1 completed-cell">${a.completed || ''}</td>` +
             `<td class="border px-2 py-1"><div class="article-body ${hiddenClass}">${bodyHtml}</div></td>`;
           tbody.appendChild(tr);

--- a/test/extractDateLocation.test.js
+++ b/test/extractDateLocation.test.js
@@ -9,6 +9,13 @@ test('extracts date and location from CNW style sentence', () => {
   assert.equal(res.location, 'EDMONTON, AB');
 });
 
+test('handles lines with a prefixed date', () => {
+  const text = 'Jun 03, 2025, 08:44 ET Share this article SANTO DOMINGO, Dominican Republic, June 3, 2025 /CNW/ - Something happened.';
+  const res = extractDateLocation(text);
+  assert.equal(res.date, 'June 3, 2025');
+  assert.equal(res.location, 'SANTO DOMINGO, Dominican Republic');
+});
+
 test('returns empty strings when pattern missing', () => {
   const res = extractDateLocation('No date or location here.');
   assert.equal(res.date, '');


### PR DESCRIPTION
## Summary
- tweak extract parties prompt to explicitly request transaction type
- keep transaction type with acquiror, seller, and target in the UI
- adjust buttons to read "Extract Parties & Type"
- improve location extraction logic and add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68406ed6aac08331b5038d2de727f070