### PR TITLE
Refine enrichment pipeline

### DIFF
--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -60,9 +60,13 @@ async function run(db, id) {
     [id, date, location]
   );
 
-  const row2 = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
+  const row2 = await db.get(
+    'SELECT completed FROM article_enrichments WHERE article_id = ?',
+    [id]
+  );
   const completed = row2 && row2.completed ? row2.completed.split(',') : [];
-  if (!completed.includes('dateLocation')) completed.push('dateLocation');
+  if (date && !completed.includes('date')) completed.push('date');
+  if (location && !completed.includes('location')) completed.push('location');
   await db.run(
     'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
     [completed.join(','), id]

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -4,8 +4,10 @@ const extractParties = require('./extractParties');
 
 module.exports = (db, openai) => {
   return async function processArticle(id) {
-    await fetchBody(db, id);
-    await extractDateLocation(db, id);
+    const bodyRes = await fetchBody(db, id);
+    if (bodyRes && bodyRes.body) {
+      await extractDateLocation(db, id);
+    }
     await extractParties(db, openai, id);
   };
 };


### PR DESCRIPTION
## Summary
- update pipeline so date/location extraction only runs after article text is fetched
- split `date` and `location` statuses in enrichment tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684071dbd9ac833190dcd7e72a577330