### PR TITLE
Update standard prompt and add embeddings

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ async function initDb() {
       'INSERT INTO prompts (name, template) VALUES (?, ?)',
       [
         'extractParties',
-        'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Respond with JSON {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}. Text: "{text}"'
+        'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Anything relating to one party buying, acquiring another is considered "M&A". The target and seller are often the same in an M&A transaction, but the target may also be select assets or a division of the seller. In a financing, the company issuing the financing is the seller. If none are mentioned, respond with JSON {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}.  Text: "{text}"'
       ]
     );
   }

--- a/lib/enrichment/fetchBody.js
+++ b/lib/enrichment/fetchBody.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 
-async function fetchBody(db, id) {
+async function fetchBody(db, openai, id) {
   const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
 
@@ -58,11 +58,26 @@ async function fetchBody(db, id) {
     text = container.text().trim();
   }
 
+  let embeddingJson = null;
+  if (openai && openai.embeddings && typeof openai.embeddings.create === 'function') {
+    try {
+      const resp = await openai.embeddings.create({
+        model: 'text-embedding-ada-002',
+        input: text
+      });
+      if (resp && resp.data && resp.data[0] && resp.data[0].embedding) {
+        embeddingJson = JSON.stringify(resp.data[0].embedding);
+      }
+    } catch (e) {
+      // ignore embedding errors
+    }
+  }
+
   await db.run(
-    `INSERT INTO article_enrichments (article_id, body)
-       VALUES (?, ?)
-       ON CONFLICT(article_id) DO UPDATE SET body = excluded.body`,
-    [id, text]
+    `INSERT INTO article_enrichments (article_id, body, embedding)
+       VALUES (?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET body = excluded.body, embedding = COALESCE(excluded.embedding, embedding)`,
+    [id, text, embeddingJson]
   );
 
   const row = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -4,7 +4,7 @@ const extractParties = require('./extractParties');
 
 module.exports = (db, openai) => {
   return async function processArticle(id) {
-    const bodyRes = await fetchBody(db, id);
+    const bodyRes = await fetchBody(db, openai, id);
     if (bodyRes && bodyRes.body) {
       await extractDateLocation(db, id);
     }

--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -73,7 +73,7 @@ function getFirstSentence(text) {
 }
 
 const DEFAULT_TEMPLATE =
-  'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Respond with JSON in the form {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}. Text: "{text}"';
+  'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Anything relating to one party buying, acquiring another is considered "M&A". The target and seller are often the same in an M&A transaction, but the target may also be select assets or a division of the seller. In a financing, the company issuing the financing is the seller. If none are mentioned, respond with JSON {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}.  Text: "{text}"';
 
 async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) {
   const firstSentence = getFirstSentence(body);

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -99,7 +99,7 @@ router.get('/enrich-list', async (req, res) => {
 router.post('/:id/enrich', async (req, res) => {
   const { id } = req.params;
   try {
-    const bodyRes = await fetchBody(db, id);
+    const bodyRes = await fetchBody(db, openai, id);
     const dateLocRes = await extractDateLocation(db, id);
     res.json({ success: true, body: bodyRes.body, ...dateLocRes });
   } catch (err) {


### PR DESCRIPTION
## Summary
- expand default prompt for party extraction
- seed DB with new prompt template
- generate embeddings when fetching article text
- pass OpenAI client through enrichment pipeline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68407c97a78c833185f90f4e50e7d049