### PR TITLE
Add semantic search page

### DIFF
--- a/public/enrich.html
+++ b/public/enrich.html
@@ -10,6 +10,7 @@
       <a href="/" class="text-blue-600 underline">Home</a>
       <a href="/manage.html" class="text-blue-600 underline">Manage Sources, Filters & Prompts</a>
       <a href="/enrich.html" class="font-semibold">Today's M&A</a>
+      <a href="/semantic-search.html" class="text-blue-600 underline">Semantic Search</a>
     </nav>
     <h1 class="text-2xl font-bold mb-4">Today's M&A Articles</h1>
 

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
       <a href="/" class="font-semibold">Home</a>
       <a href="/manage.html" class="text-blue-600 underline">Manage Sources, Filters & Prompts</a>
       <a href="/enrich.html" class="text-blue-600 underline">Today's M&A</a>
+      <a href="/semantic-search.html" class="text-blue-600 underline">Semantic Search</a>
     </nav>
     <h1 class="text-2xl font-bold mb-4">News Scraper</h1>
 

--- a/public/manage.html
+++ b/public/manage.html
@@ -10,6 +10,7 @@
       <a href="/" class="text-blue-600 underline">Home</a>
       <a href="/manage.html" class="font-semibold">Manage Sources, Filters & Prompts</a>
       <a href="/enrich.html" class="text-blue-600 underline">Today's M&A</a>
+      <a href="/semantic-search.html" class="text-blue-600 underline">Semantic Search</a>
     </nav>
     <h1 class="text-2xl font-bold mb-4">Manage Sources, Filters & Prompts</h1>
 

--- a/public/semantic-search.html
+++ b/public/semantic-search.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Semantic Search</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="p-4">
+    <nav class="mb-4 space-x-4">
+      <a href="/" class="text-blue-600 underline">Home</a>
+      <a href="/manage.html" class="text-blue-600 underline">Manage Sources, Filters &amp; Prompts</a>
+      <a href="/enrich.html" class="text-blue-600 underline">Today's M&amp;A</a>
+      <a href="/semantic-search.html" class="font-semibold">Semantic Search</a>
+    </nav>
+    <h1 class="text-2xl font-bold mb-4">Semantic Search</h1>
+
+    <div class="mb-4 space-x-2">
+      <input id="queryInput" class="border px-2 py-1" placeholder="Search text" />
+      <input id="thresholdInput" class="border px-2 py-1 w-24" type="number" step="0.01" min="0" max="1" value="0.8" />
+      <button id="searchBtn" class="bg-blue-500 text-white px-3 py-1 rounded">Search</button>
+    </div>
+
+    <table class="table-auto w-full border-collapse">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">Title</th>
+          <th class="border px-2 py-1">Description</th>
+          <th class="border px-2 py-1">Score</th>
+          <th class="border px-2 py-1">Link</th>
+        </tr>
+      </thead>
+      <tbody id="resultsBody"></tbody>
+    </table>
+
+    <script>
+      function addRow(a, matched) {
+        const tr = document.createElement('tr');
+        if (matched) tr.classList.add('bg-green-200');
+        tr.innerHTML =
+          `<td class="border px-2 py-1">${a.title}</td>` +
+          `<td class="border px-2 py-1">${a.description || ''}</td>` +
+          `<td class="border px-2 py-1">${a.score.toFixed(3)}</td>` +
+          `<td class="border px-2 py-1"><a href="${a.link}" target="_blank" class="text-blue-600 underline">Link</a></td>`;
+        return tr;
+      }
+
+      async function doSearch() {
+        const q = document.getElementById('queryInput').value.trim();
+        const threshold = parseFloat(document.getElementById('thresholdInput').value) || 0.8;
+        if (!q) return;
+        const params = new URLSearchParams({ q, threshold });
+        const res = await fetch('/articles/semantic-search?' + params.toString());
+        const data = await res.json();
+        const tbody = document.getElementById('resultsBody');
+        tbody.innerHTML = '';
+        (data.matches || []).forEach(a => tbody.appendChild(addRow(a, true)));
+        (data.others || []).forEach(a => tbody.appendChild(addRow(a, false)));
+      }
+
+      document.getElementById('searchBtn').addEventListener('click', doSearch);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement cosine similarity and semantic search route
- add Semantic Search page with query input and threshold
- link new page from existing navigation bars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68407ea4404483318f2206ceeace85c8