### PR TITLE
Add wildcard support for keyword filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ At the time of writing all **8** tests pass.
 PORT=4000 npm start
 ```
 
+## Keyword filters
+
+Keyword filters support simple wildcards. Use `*` to match any sequence of
+characters and `?` to match a single character. For example, a filter value of
+`divest*` will match `divestiture` or `divests`.
+

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -19,10 +19,22 @@ async function runFilters(db, articleIds, logs) {
       if (filter.type === 'keyword') {
         const keywords = (filter.value || '')
           .split(',')
-          .map(k => k.trim().toLowerCase())
+          .map(k => k.trim())
           .filter(Boolean);
-        const text = `${article.title || ''} ${article.description || ''}`.toLowerCase();
-        const matched = keywords.some(kw => text.includes(kw));
+
+        const text = `${article.title || ''} ${article.description || ''}`;
+
+        const matched = keywords.some(kw => {
+          const regex = new RegExp(
+            kw
+              .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+              .replace(/\*/g, '.*')
+              .replace(/\?/g, '.'),
+            'i'
+          );
+          return regex.test(text);
+        });
+
         if (matched) {
           await db.run(
             'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
     </table>
 
     <h2 class="text-xl font-semibold mb-2">Active Filters</h2>
+    <p class="text-sm text-gray-600 mb-2">Use <code>*</code> for any number of characters and <code>?</code> for a single character in keyword filters.</p>
     <table class="table-auto w-full mb-6 border-collapse" id="filtersTable">
       <thead>
         <tr>

--- a/public/manage.html
+++ b/public/manage.html
@@ -59,6 +59,7 @@
       <label class="mr-2"><input type="checkbox" id="filter_active" checked /> Active</label>
       <button type="submit" class="bg-green-500 text-white px-2 py-1 rounded">Add</button>
     </form>
+    <p class="text-sm text-gray-600 mb-4">Use <code>*</code> for any number of characters and <code>?</code> for a single character.</p>
 
     <table class="table-auto w-full mb-6 border-collapse" id="filtersTable">
       <thead>

--- a/test/runFilters.test.js
+++ b/test/runFilters.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { runFilters } = require('../lib/filters');
+
+function createMockDb(articles, filters) {
+  const matches = [];
+  return {
+    get: async (sql, params) => articles[params[0]],
+    all: async () => filters,
+    run: async (sql, params) => {
+      if (sql.includes('article_filter_matches')) {
+        matches.push({ article_id: params[0], filter_id: params[1] });
+      }
+      return { changes: 1 };
+    },
+    matches
+  };
+}
+
+test('keyword filters support wildcard *', async () => {
+  const articles = { 1: { title: 'Company plans divestiture', description: '' } };
+  const filters = [{ id: 5, type: 'keyword', value: 'divest*', active: 1 }];
+  const db = createMockDb(articles, filters);
+
+  await runFilters(db, [1], []);
+  assert.equal(db.matches.length, 1);
+  assert.deepEqual(db.matches[0], { article_id: 1, filter_id: 5 });
+});


### PR DESCRIPTION
## Summary
- allow `*` and `?` wildcards in keyword filters
- document wildcard usage in README
- show wildcard hints on the manage and main pages
- test wildcard matching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68408555504c833185343f4da8d75af9