### PR TITLE
Apply repo recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.db

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Newsly is a small Express application that scrapes news sources and stores artic
 ## Prerequisites
 
 - Node.js 18 or newer (the repo uses Node.js 22 via the `.replit` config)
-- If you plan to run enrichment routes, set the `OPENAI_API_KEY` environment variable
+- The server uses a local SQLite database at `raw_articles.db`
+- To run enrichment routes you must set the `OPENAI_API_KEY` environment variable
 
 ## Setup
 
-Install dependencies using npm:
+Install dependencies using npm before running the server:
 
 ```bash
 npm install
@@ -24,6 +25,11 @@ npm start
 ```
 
 The server listens on the port defined by `PORT` or defaults to `3000`.
+
+### Environment variables
+
+- `OPENAI_API_KEY` – required for enrichment endpoints
+- `PORT` – optional port number (defaults to `3000`)
 
 ## Project structure
 
@@ -42,7 +48,7 @@ Run all tests with:
 npm test
 ```
 
-At the time of writing all **8** tests pass.
+At the time of writing all **14** tests pass.
 
 ## Example commands
 

--- a/lib/enrichment/fetchAndStoreBody.js
+++ b/lib/enrichment/fetchAndStoreBody.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 
-async function fetchBody(db, openai, id) {
+async function fetchAndStoreBody(db, openai, id) {
   const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
 
@@ -94,4 +94,4 @@ async function fetchBody(db, openai, id) {
   return { body: text, completed: completed.join(',') };
 }
 
-module.exports = fetchBody;
+module.exports = fetchAndStoreBody;

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -1,10 +1,10 @@
-const fetchBody = require('./fetchBody');
+const fetchAndStoreBody = require('./fetchAndStoreBody');
 const extractDateLocation = require('./extractDateLocation');
 const extractParties = require('./extractParties');
 
 module.exports = (db, openai) => {
   return async function processArticle(id) {
-    const bodyRes = await fetchBody(db, openai, id);
+    const bodyRes = await fetchAndStoreBody(db, openai, id);
     if (bodyRes && bodyRes.body) {
       await extractDateLocation(db, id);
     }

--- a/lib/fetchBodyText.js
+++ b/lib/fetchBodyText.js
@@ -42,7 +42,7 @@ function extractParagraphs(html) {
   return stripTags(html).trim();
 }
 
-async function fetchBody(url, bodySelector = null, http) {
+async function fetchBodyText(url, bodySelector = null, http) {
   const html = await fetchHtml(url, http);
 
   const fallbackSelectors = [
@@ -68,4 +68,4 @@ async function fetchBody(url, bodySelector = null, http) {
   return extractParagraphs(section);
 }
 
-module.exports = fetchBody;
+module.exports = fetchBodyText;

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -42,7 +42,17 @@ async function runFilters(db, articleIds, logs) {
           );
         }
       } else if (filter.type === 'embedding') {
-        // TODO: implement semantic filtering using embeddings
+        // Placeholder for future embedding-based filtering. The idea is to
+        // compare the article's embedding vector against the filter's stored
+        // embedding and store a match when the cosine similarity exceeds a
+        // configured threshold.
+        //
+        // e.g.
+        //   const articleVec = JSON.parse(article.embedding);
+        //   const filterVec = JSON.parse(filter.value);
+        //   if (cosineSimilarity(articleVec, filterVec) > filter.threshold) {
+        //     await db.run('INSERT INTO article_filter_matches ...');
+        //   }
       }
     }
   }

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { OpenAI } = require('openai');
 const db = require('../db');
-const fetchBody = require('../lib/enrichment/fetchBody');
+const fetchAndStoreBody = require('../lib/enrichment/fetchAndStoreBody');
 const extractDateLocation = require('../lib/enrichment/extractDateLocation');
 const extractParties = require('../lib/enrichment/extractParties');
 
@@ -152,7 +152,7 @@ router.get('/enriched-list', async (req, res) => {
 router.post('/:id/enrich', async (req, res) => {
   const { id } = req.params;
   try {
-    const bodyRes = await fetchBody(db, openai, id);
+    const bodyRes = await fetchAndStoreBody(db, openai, id);
     const dateLocRes = await extractDateLocation(db, id);
     res.json({ success: true, body: bodyRes.body, ...dateLocRes });
   } catch (err) {

--- a/test/enrichment/fetchBody.test.js
+++ b/test/enrichment/fetchBody.test.js
@@ -1,17 +1,17 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const fetchBody = require('../../lib/fetchBody');
+const fetchBodyText = require('../../lib/fetchBodyText');
 
 test('uses provided selector to extract text', async () => {
   const html = '<div id="main"><p>First</p><p>Second</p></div>';
   const mockHttp = { get: async () => ({ data: html }) };
-  const body = await fetchBody('http://example.com', '#main', mockHttp);
+  const body = await fetchBodyText('http://example.com', '#main', mockHttp);
   assert.equal(body, 'First\nSecond');
 });
 
 test('falls back to article tag when selector missing', async () => {
   const html = '<article><p>Foo</p><p>Bar</p></article>';
   const mockHttp = { get: async () => ({ data: html }) };
-  const body = await fetchBody('http://example.com', null, mockHttp);
+  const body = await fetchBodyText('http://example.com', null, mockHttp);
   assert.equal(body, 'Foo\nBar');
 });


### PR DESCRIPTION
## Summary
- ignore DB and node_modules files
- clarify prerequisites and environment variables
- rename body fetching helpers to avoid confusion
- outline approach for embedding filters
- update tests for renamed modules

## Testing
- `npm test`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68409a4c9ad083318c44a552ba732ed9