### PR TITLE
Add enrichment logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ async function initDb() {
     body TEXT,
     transaction_type TEXT,
     completed TEXT,
+    log TEXT,
     FOREIGN KEY(article_id) REFERENCES articles(id)
   )`);
 
@@ -108,6 +109,10 @@ async function initDb() {
   const hasTx = aeInfo.some(r => r.name === 'transaction_type');
   if (!hasTx) {
     await db.run('ALTER TABLE article_enrichments ADD COLUMN transaction_type TEXT');
+  }
+  const hasLog = aeInfo.some(r => r.name === 'log');
+  if (!hasLog) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN log TEXT');
   }
 
   await db.run(`CREATE TABLE IF NOT EXISTS sources (

--- a/lib/enrichment/appendLog.js
+++ b/lib/enrichment/appendLog.js
@@ -1,0 +1,14 @@
+async function appendLog(db, id, message) {
+  const row = await db.get('SELECT log FROM article_enrichments WHERE article_id = ?', [id]);
+  const ts = new Date().toISOString();
+  const prev = row && row.log ? row.log + '\n' : '';
+  const log = `${prev}${ts} ${message}`;
+  await db.run(
+    `INSERT INTO article_enrichments (article_id, log)
+     VALUES (?, ?)
+     ON CONFLICT(article_id) DO UPDATE SET log = excluded.log`,
+    [id, log]
+  );
+}
+
+module.exports = appendLog;

--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 const extractDateLocation = require('../extractDateLocation');
+const appendLog = require('./appendLog');
 
 async function run(db, id) {
   const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
@@ -60,6 +61,8 @@ async function run(db, id) {
     [id, date, location]
   );
 
+  await appendLog(db, id, `Extracted date "${date}" and location "${location}"`);
+
   const row2 = await db.get(
     'SELECT completed FROM article_enrichments WHERE article_id = ?',
     [id]
@@ -71,6 +74,8 @@ async function run(db, id) {
     'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
     [completed.join(','), id]
   );
+
+  await appendLog(db, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { date, location, completed: completed.join(',') };
 }

--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -4,6 +4,7 @@ const {
   DEFAULT_TEMPLATE
 } = require('../extractParties');
 const { getPrompt } = require('../prompts');
+const appendLog = require('./appendLog');
 
 async function extractParties(db, openai, id) {
   const row = await db.get(
@@ -35,6 +36,8 @@ async function extractParties(db, openai, id) {
     [id, acquiror, seller, target, transactionType]
   );
 
+  await appendLog(db, id, `Extracted parties a:${acquiror} s:${seller} t:${target} type:${transactionType}`);
+
   const row2 = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
   const completed = row2 && row2.completed ? row2.completed.split(',') : [];
   if (!completed.includes('parties')) completed.push('parties');
@@ -42,6 +45,8 @@ async function extractParties(db, openai, id) {
     `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
     [completed.join(','), id]
   );
+
+  await appendLog(db, id, `Updated completed steps: ${completed.join(',')}`);
 
   return {
     firstSentence,

--- a/lib/enrichment/fetchAndStoreBody.js
+++ b/lib/enrichment/fetchAndStoreBody.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
+const appendLog = require('./appendLog');
 
 async function fetchAndStoreBody(db, openai, id) {
   const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
@@ -80,6 +81,11 @@ async function fetchAndStoreBody(db, openai, id) {
     [id, text, embeddingJson]
   );
 
+  await appendLog(db, id, `Fetched body text (${text.length} chars)`);
+  if (embeddingJson) {
+    await appendLog(db, id, 'Generated embedding');
+  }
+
   const row = await db.get('SELECT completed, embedding FROM article_enrichments WHERE article_id = ?', [id]);
   const completed = row && row.completed ? row.completed.split(',') : [];
   if (!completed.includes('body')) completed.push('body');
@@ -90,6 +96,8 @@ async function fetchAndStoreBody(db, openai, id) {
     `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
     [completed.join(','), id]
   );
+
+  await appendLog(db, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { body: text, completed: completed.join(',') };
 }

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -62,7 +62,7 @@ router.get('/mna-today', async (req, res) => {
     SELECT a.id, a.title, a.description, a.time, a.link,
            ae.body, ae.acquiror, ae.seller, ae.target,
            ae.location, ae.article_date, ae.completed,
-           ae.transaction_type
+           ae.transaction_type, ae.log
     FROM articles a
     JOIN article_filter_matches m ON a.id = m.article_id
     JOIN filters f ON f.id = m.filter_id
@@ -95,7 +95,7 @@ router.get('/enrich-list', async (req, res) => {
     SELECT DISTINCT a.id, a.title, a.description, a.time, a.link,
            ae.body, ae.acquiror, ae.seller, ae.target,
            ae.location, ae.article_date, ae.completed,
-           ae.transaction_type, ae.embedding
+           ae.transaction_type, ae.embedding, ae.log
     FROM articles a
     ${join}
     LEFT JOIN article_enrichments ae ON a.id = ae.article_id
@@ -130,7 +130,7 @@ router.get('/enriched-list', async (req, res) => {
     `SELECT a.id, a.title, a.description, a.time, a.link,
             ae.body, ae.acquiror, ae.seller, ae.target,
             ae.location, ae.article_date, ae.completed,
-            ae.transaction_type
+            ae.transaction_type, ae.log
        FROM articles a
        JOIN article_enrichments ae ON a.id = ae.article_id
       WHERE ae.body IS NOT NULL AND ae.embedding IS NOT NULL


### PR DESCRIPTION
## Summary
- add `log` column to enriched articles
- log enrichment steps with helper
- expose logs in article endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840ea480ed083319d949f7610e438a9