### PR TITLE
Fix insertedIds mapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ app.get('/scrape', async (req, res) => {
 
       const results = await Promise.all(insertPromises);
       const inserted = results.reduce((acc, cur) => acc + cur.changes, 0);
-      const insertedIds = results.filter(r => r.changes > 0).map(r => r.id);
+      const insertedIds = results.filter(r => r.changes > 0).map(r => r.lastID);
       insertedTotal += inserted;
       logs.push(`Inserted ${inserted} new articles from ${source.base_url}`);
       if (insertedIds.length) {
@@ -277,7 +277,7 @@ app.get('/scrape-enrich', async (req, res) => {
 
       const results = await Promise.all(insertPromises);
       const inserted = results.reduce((acc, cur) => acc + cur.changes, 0);
-      const insertedIds = results.filter(r => r.changes > 0).map(r => r.id);
+      const insertedIds = results.filter(r => r.changes > 0).map(r => r.lastID);
       insertedTotal += inserted;
       logs.push(`Inserted ${inserted} new articles from ${source.base_url}`);
 


### PR DESCRIPTION
## Summary
- use `r.lastID` when collecting inserted IDs
- ensure inserted IDs only include rows with changes > 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840b161e37c83318a6d6ebf023d65dc