### PR TITLE
Add config database for sources & filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Newsly is a small Express application that scrapes news sources and stores artic
 
 - Node.js 18 or newer (the repo uses Node.js 22 via the `.replit` config)
 - The server uses a local SQLite database at `raw_articles.db`
+- Scraping sources, filters and prompts are stored in `config.db`
 - To run enrichment routes you must set the `OPENAI_API_KEY` environment variable
 
 ## Setup

--- a/configDb.js
+++ b/configDb.js
@@ -1,0 +1,39 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const connection = new sqlite3.Database(
+  path.join(__dirname, 'config.db')
+);
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    connection.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve({ lastID: this.lastID, changes: this.changes });
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    connection.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    connection.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+function serialize(fn) {
+  connection.serialize(fn);
+}
+
+module.exports = { run, get, all, serialize, raw: connection };

--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -3,11 +3,11 @@ const cheerio = require('cheerio');
 const extractDateLocation = require('../extractDateLocation');
 const appendLog = require('./appendLog');
 
-async function run(db, id) {
-  const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
+async function run(articleDb, configDb, id) {
+  const article = await articleDb.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
 
-  const sources = await db.all('SELECT * FROM sources');
+  const sources = await configDb.all('SELECT * FROM sources');
 
   let dateSelector = null;
   let locationSelector = null;
@@ -42,7 +42,7 @@ async function run(db, id) {
     } catch (e) {}
   }
 
-  const row = await db.get(
+  const row = await articleDb.get(
     'SELECT body FROM article_enrichments WHERE article_id = ?',
     [id]
   );
@@ -54,28 +54,28 @@ async function run(db, id) {
     if (!date) date = fallback.date;
     if (!location) location = fallback.location;
   }
-  await db.run(
+  await articleDb.run(
     `INSERT INTO article_enrichments (article_id, article_date, location)
        VALUES (?, ?, ?)
        ON CONFLICT(article_id) DO UPDATE SET article_date = excluded.article_date, location = excluded.location`,
     [id, date, location]
   );
 
-  await appendLog(db, id, `Extracted date "${date}" and location "${location}"`);
+  await appendLog(articleDb, id, `Extracted date "${date}" and location "${location}"`);
 
-  const row2 = await db.get(
+  const row2 = await articleDb.get(
     'SELECT completed FROM article_enrichments WHERE article_id = ?',
     [id]
   );
   const completed = row2 && row2.completed ? row2.completed.split(',') : [];
   if (date && !completed.includes('date')) completed.push('date');
   if (location && !completed.includes('location')) completed.push('location');
-  await db.run(
+  await articleDb.run(
     'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
     [completed.join(','), id]
   );
 
-  await appendLog(db, id, `Updated completed steps: ${completed.join(',')}`);
+  await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { date, location, completed: completed.join(',') };
 }

--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -6,8 +6,8 @@ const {
 const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
 
-async function extractParties(db, openai, id) {
-  const row = await db.get(
+async function extractParties(articleDb, configDb, openai, id) {
+  const row = await articleDb.get(
     `SELECT a.title, e.body FROM articles a JOIN article_enrichments e ON a.id = e.article_id WHERE a.id = ?`,
     [id]
   );
@@ -17,7 +17,7 @@ async function extractParties(db, openai, id) {
 
   const firstSentence = getFirstSentence(row.body);
   const titleAndSentence = `${row.title || ''} ${firstSentence}`.trim();
-  const template = await getPrompt(db, 'extractParties', DEFAULT_TEMPLATE);
+  const template = await getPrompt(configDb, 'extractParties', DEFAULT_TEMPLATE);
   const prompt = template.replace('{text}', titleAndSentence);
 
   const resp = await openai.chat.completions.create({
@@ -29,24 +29,24 @@ async function extractParties(db, openai, id) {
   const output = resp.choices[0].message.content.trim();
   const { acquiror, seller, target, transactionType } = parseOpenAIResponse(output);
 
-  await db.run(
+  await articleDb.run(
     `INSERT INTO article_enrichments (article_id, acquiror, seller, target, transaction_type)
        VALUES (?, ?, ?, ?, ?)
        ON CONFLICT(article_id) DO UPDATE SET acquiror = excluded.acquiror, seller = excluded.seller, target = excluded.target, transaction_type = excluded.transaction_type`,
     [id, acquiror, seller, target, transactionType]
   );
 
-  await appendLog(db, id, `Extracted parties a:${acquiror} s:${seller} t:${target} type:${transactionType}`);
+  await appendLog(articleDb, id, `Extracted parties a:${acquiror} s:${seller} t:${target} type:${transactionType}`);
 
-  const row2 = await db.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
+  const row2 = await articleDb.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
   const completed = row2 && row2.completed ? row2.completed.split(',') : [];
   if (!completed.includes('parties')) completed.push('parties');
-  await db.run(
+  await articleDb.run(
     `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
     [completed.join(','), id]
   );
 
-  await appendLog(db, id, `Updated completed steps: ${completed.join(',')}`);
+  await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return {
     firstSentence,

--- a/lib/enrichment/fetchAndStoreBody.js
+++ b/lib/enrichment/fetchAndStoreBody.js
@@ -2,11 +2,11 @@ const axios = require('axios');
 const cheerio = require('cheerio');
 const appendLog = require('./appendLog');
 
-async function fetchAndStoreBody(db, openai, id) {
-  const article = await db.get('SELECT link FROM articles WHERE id = ?', [id]);
+async function fetchAndStoreBody(articleDb, configDb, openai, id) {
+  const article = await articleDb.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
 
-  const sources = await db.all('SELECT * FROM sources');
+  const sources = await configDb.all('SELECT * FROM sources');
 
   let bodySelector = null;
   try {
@@ -74,30 +74,30 @@ async function fetchAndStoreBody(db, openai, id) {
     }
   }
 
-  await db.run(
+  await articleDb.run(
     `INSERT INTO article_enrichments (article_id, body, embedding)
        VALUES (?, ?, ?)
        ON CONFLICT(article_id) DO UPDATE SET body = excluded.body, embedding = COALESCE(excluded.embedding, embedding)`,
     [id, text, embeddingJson]
   );
 
-  await appendLog(db, id, `Fetched body text (${text.length} chars)`);
+  await appendLog(articleDb, id, `Fetched body text (${text.length} chars)`);
   if (embeddingJson) {
-    await appendLog(db, id, 'Generated embedding');
+    await appendLog(articleDb, id, 'Generated embedding');
   }
 
-  const row = await db.get('SELECT completed, embedding FROM article_enrichments WHERE article_id = ?', [id]);
+  const row = await articleDb.get('SELECT completed, embedding FROM article_enrichments WHERE article_id = ?', [id]);
   const completed = row && row.completed ? row.completed.split(',') : [];
   if (!completed.includes('body')) completed.push('body');
   if ((embeddingJson || row.embedding) && !completed.includes('embedding')) {
     completed.push('embedding');
   }
-  await db.run(
+  await articleDb.run(
     `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
     [completed.join(','), id]
   );
 
-  await appendLog(db, id, `Updated completed steps: ${completed.join(',')}`);
+  await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { body: text, completed: completed.join(',') };
 }

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -2,12 +2,12 @@ const fetchAndStoreBody = require('./fetchAndStoreBody');
 const extractDateLocation = require('./extractDateLocation');
 const extractParties = require('./extractParties');
 
-module.exports = (db, openai) => {
+module.exports = (articleDb, configDb, openai) => {
   return async function processArticle(id) {
-    const bodyRes = await fetchAndStoreBody(db, openai, id);
+    const bodyRes = await fetchAndStoreBody(articleDb, configDb, openai, id);
     if (bodyRes && bodyRes.body) {
-      await extractDateLocation(db, id);
+      await extractDateLocation(articleDb, configDb, id);
     }
-    await extractParties(db, openai, id);
+    await extractParties(articleDb, configDb, openai, id);
   };
 };

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,7 +1,9 @@
 // Filter utilities
-async function runFilters(db, articleIds, logs) {
+// articleDb is the main articles database
+// configDb stores filters, prompts and sources
+async function runFilters(articleDb, configDb, articleIds, logs) {
   if (!articleIds.length) return;
-  const filters = await db.all('SELECT * FROM filters WHERE active = 1');
+  const filters = await configDb.all('SELECT * FROM filters WHERE active = 1');
 
   if (!filters.length) {
     logs && logs.push('No active filters to run');
@@ -9,7 +11,7 @@ async function runFilters(db, articleIds, logs) {
   }
 
   for (const id of articleIds) {
-    const article = await db.get(
+    const article = await articleDb.get(
       'SELECT title, description FROM articles WHERE id = ?',
       [id]
     );
@@ -36,7 +38,7 @@ async function runFilters(db, articleIds, logs) {
         });
 
         if (matched) {
-          await db.run(
+          await articleDb.run(
             'INSERT INTO article_filter_matches (article_id, filter_id) VALUES (?, ?)',
             [id, filter.id]
           );

--- a/routes/filters.js
+++ b/routes/filters.js
@@ -1,12 +1,12 @@
 const express = require('express');
-const db = require('../db');
+const configDb = require('../configDb');
 
 const router = express.Router();
 
 // Get all filters
 router.get('/', async (req, res) => {
   try {
-    const rows = await db.all('SELECT * FROM filters');
+    const rows = await configDb.all('SELECT * FROM filters');
     res.json(rows);
   } catch (err) {
     console.error(err);
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
   const { name, type, value, active = 1 } = req.body;
   try {
-    const result = await db.run(
+    const result = await configDb.run(
       'INSERT INTO filters (name, type, value, active) VALUES (?, ?, ?, ?)',
       [name, type, value, active]
     );
@@ -34,7 +34,7 @@ router.put('/:id', async (req, res) => {
   const { id } = req.params;
   const { name, type, value, active } = req.body;
   try {
-    const result = await db.run(
+    const result = await configDb.run(
       'UPDATE filters SET name = ?, type = ?, value = ?, active = ? WHERE id = ?',
       [name, type, value, active, id]
     );
@@ -49,7 +49,7 @@ router.put('/:id', async (req, res) => {
 router.delete('/:id', async (req, res) => {
   const { id } = req.params;
   try {
-    const result = await db.run('DELETE FROM filters WHERE id = ?', [id]);
+    const result = await configDb.run('DELETE FROM filters WHERE id = ?', [id]);
     res.json({ deleted: result.changes });
   } catch (err) {
     console.error(err);

--- a/routes/prompts.js
+++ b/routes/prompts.js
@@ -1,12 +1,12 @@
 const express = require('express');
-const db = require('../db');
+const configDb = require('../configDb');
 const { getPrompt, setPrompt } = require('../lib/prompts');
 
 const router = express.Router();
 
 router.get('/', async (req, res) => {
   try {
-    const rows = await db.all('SELECT name, template FROM prompts');
+    const rows = await configDb.all('SELECT name, template FROM prompts');
     res.json(rows);
   } catch (err) {
     console.error(err);
@@ -17,7 +17,7 @@ router.get('/', async (req, res) => {
 router.get('/:name', async (req, res) => {
   const { name } = req.params;
   try {
-    const template = await getPrompt(db, name);
+    const template = await getPrompt(configDb, name);
     if (!template) return res.status(404).json({ error: 'Prompt not found' });
     res.json({ name, template });
   } catch (err) {
@@ -30,7 +30,7 @@ router.put('/:name', async (req, res) => {
   const { name } = req.params;
   const { template } = req.body;
   try {
-    const changes = await setPrompt(db, name, template);
+    const changes = await setPrompt(configDb, name, template);
     res.json({ updated: changes });
   } catch (err) {
     console.error(err);

--- a/routes/sources.js
+++ b/routes/sources.js
@@ -1,12 +1,12 @@
 const express = require('express');
-const db = require('../db');
+const configDb = require('../configDb');
 
 const router = express.Router();
 
 // Get all scraping sources
 router.get('/', async (req, res) => {
   try {
-    const rows = await db.all('SELECT * FROM sources');
+    const rows = await configDb.all('SELECT * FROM sources');
     res.json(rows);
   } catch (err) {
     console.error(err);
@@ -43,7 +43,7 @@ router.post('/', async (req, res) => {
   ];
 
   try {
-    const result = await db.run(
+    const result = await configDb.run(
       `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector, body_selector, location_selector, date_selector)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       params
@@ -59,7 +59,7 @@ router.post('/', async (req, res) => {
 router.delete('/:id', async (req, res) => {
   const { id } = req.params;
   try {
-    const result = await db.run('DELETE FROM sources WHERE id = ?', [id]);
+    const result = await configDb.run('DELETE FROM sources WHERE id = ?', [id]);
     res.json({ deleted: result.changes });
   } catch (err) {
     console.error(err);
@@ -98,7 +98,7 @@ router.put('/:id', async (req, res) => {
   ];
 
   try {
-    const result = await db.run(
+    const result = await configDb.run(
       `UPDATE sources SET base_url = ?, article_selector = ?, title_selector = ?, description_selector = ?, time_selector = ?, link_selector = ?, image_selector = ?, body_selector = ?, location_selector = ?, date_selector = ? WHERE id = ?`,
       params
     );

--- a/test/runFilters.test.js
+++ b/test/runFilters.test.js
@@ -2,11 +2,10 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { runFilters } = require('../lib/filters');
 
-function createMockDb(articles, filters) {
+function createArticleDb(articles) {
   const matches = [];
   return {
     get: async (sql, params) => articles[params[0]],
-    all: async () => filters,
     run: async (sql, params) => {
       if (sql.includes('article_filter_matches')) {
         matches.push({ article_id: params[0], filter_id: params[1] });
@@ -17,12 +16,19 @@ function createMockDb(articles, filters) {
   };
 }
 
+function createConfigDb(filters) {
+  return {
+    all: async () => filters,
+  };
+}
+
 test('keyword filters support wildcard *', async () => {
   const articles = { 1: { title: 'Company plans divestiture', description: '' } };
   const filters = [{ id: 5, type: 'keyword', value: 'divest*', active: 1 }];
-  const db = createMockDb(articles, filters);
+  const articleDb = createArticleDb(articles);
+  const configDb = createConfigDb(filters);
 
-  await runFilters(db, [1], []);
-  assert.equal(db.matches.length, 1);
-  assert.deepEqual(db.matches[0], { article_id: 1, filter_id: 5 });
+  await runFilters(articleDb, configDb, [1], []);
+  assert.equal(articleDb.matches.length, 1);
+  assert.deepEqual(articleDb.matches[0], { article_id: 1, filter_id: 5 });
 });


### PR DESCRIPTION
## Summary
- add `configDb.js` for config storage
- store sources, filters and prompts in `config.db`
- update scraping and enrichment pipelines to use the new database
- adjust API routes for separate config storage
- update README with new database location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841a86f8e188331ab72742a9f7413a0