### PR TITLE
Add summarization enrichment step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Newsly
 
 Newsly is a small Express application that scrapes news sources and stores articles in a SQLite database. Optional enrichment tasks use the OpenAI API to extract M&A details. When extracting the acquiror, seller and target, the same request also classifies whether the article is about an "M&A" transaction, a "Financing" or "Other".
+Articles can also be summarized with sector and industry labels using GPT.
 
 ## Prerequisites
 

--- a/index.js
+++ b/index.js
@@ -85,6 +85,20 @@ async function initDb() {
     );
   }
 
+  const sumRow = await configDb.get(
+    'SELECT COUNT(*) as count FROM prompts WHERE name = ?',
+    ['summarizeArticle']
+  );
+  if (sumRow.count === 0) {
+    await configDb.run(
+      'INSERT INTO prompts (name, template) VALUES (?, ?)',
+      [
+        'summarizeArticle',
+        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Respond with JSON {"summary":"...","sector":"...","industry":"..."}. Text: "{text}"'
+      ]
+    );
+  }
+
   const aeInfo = await db.all('PRAGMA table_info(article_enrichments)');
   const hasBody = aeInfo.some(r => r.name === 'body');
   if (!hasBody) {
@@ -113,6 +127,14 @@ async function initDb() {
   const hasLog = aeInfo.some(r => r.name === 'log');
   if (!hasLog) {
     await db.run('ALTER TABLE article_enrichments ADD COLUMN log TEXT');
+  }
+  const hasSummary = aeInfo.some(r => r.name === 'summary');
+  if (!hasSummary) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN summary TEXT');
+  }
+  const hasSector = aeInfo.some(r => r.name === 'sector');
+  if (!hasSector) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN sector TEXT');
   }
 
   await configDb.run(`CREATE TABLE IF NOT EXISTS sources (

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -1,6 +1,7 @@
 const fetchAndStoreBody = require('./fetchAndStoreBody');
 const extractDateLocation = require('./extractDateLocation');
 const extractParties = require('./extractParties');
+const summarizeArticle = require('./summarizeArticle');
 
 module.exports = (articleDb, configDb, openai) => {
   return async function processArticle(id) {
@@ -9,5 +10,6 @@ module.exports = (articleDb, configDb, openai) => {
       await extractDateLocation(articleDb, configDb, id);
     }
     await extractParties(articleDb, configDb, openai, id);
+    await summarizeArticle(articleDb, configDb, openai, id);
   };
 };

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -1,0 +1,67 @@
+const { getPrompt } = require('../prompts');
+const appendLog = require('./appendLog');
+
+const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Respond with JSON {"summary":"...","sector":"...","industry":"..."}. Text: "{text}"`;
+
+async function summarizeArticle(articleDb, configDb, openai, id) {
+  const row = await articleDb.get(
+    'SELECT body FROM article_enrichments WHERE article_id = ?',
+    [id]
+  );
+  if (!row || !row.body) {
+    throw new Error('Article text not found');
+  }
+
+  const template = await getPrompt(
+    configDb,
+    'summarizeArticle',
+    DEFAULT_TEMPLATE
+  );
+  const prompt = template.replace('{text}', row.body);
+
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0
+  });
+
+  const output = resp.choices[0].message.content.trim();
+  let summary = '';
+  let sector = '';
+  let industry = '';
+  try {
+    const parsed = JSON.parse(output);
+    if (parsed.summary) summary = parsed.summary;
+    if (parsed.sector) sector = parsed.sector;
+    if (parsed.clairfield_sector && !sector) sector = parsed.clairfield_sector;
+    if (parsed.industry) industry = parsed.industry;
+  } catch (e) {
+    // ignore parse errors
+  }
+
+  await articleDb.run(
+    `INSERT INTO article_enrichments (article_id, summary, sector, industry)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET summary = excluded.summary, sector = excluded.sector, industry = excluded.industry`,
+    [id, summary, sector, industry]
+  );
+
+  await appendLog(articleDb, id, `Summarized article with sector "${sector}"`);
+
+  const row2 = await articleDb.get(
+    'SELECT completed FROM article_enrichments WHERE article_id = ?',
+    [id]
+  );
+  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
+  if (!completed.includes('summary')) completed.push('summary');
+  await articleDb.run(
+    'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
+    [completed.join(','), id]
+  );
+
+  await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
+
+  return { summary, sector, industry, prompt, output, completed: completed.join(',') };
+}
+
+module.exports = summarizeArticle;

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -196,6 +196,19 @@ router.post('/:id/extract-parties', async (req, res) => {
   }
 });
 
+// Summarize article and classify sector/industry using GPT
+const summarizeArticle = require('../lib/enrichment/summarizeArticle');
+router.post('/:id/summarize', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await summarizeArticle(db, configDb, openai, id);
+    res.json({ success: true, ...result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to summarize article' });
+  }
+});
+
 // Semantic search using OpenAI embeddings
 router.get('/semantic-search', async (req, res) => {
   const query = (req.query.q || '').trim();


### PR DESCRIPTION
## Summary
- add summarization step to enrichment pipeline
- create summarizeArticle module
- add `/articles/:id/summarize` API route
- store summary and sector in database
- install default summarization prompt
- update README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841c74130f883318e35efa8a4a6f00d