### PR TITLE
Update enriched article layout

### DIFF
--- a/public/enriched.html
+++ b/public/enriched.html
@@ -56,10 +56,9 @@
       <thead>
         <tr>
           <th class="border px-2 py-1">#</th>
-          <th class="border px-2 py-1">Title</th>
           <th class="border px-2 py-1">Deal</th>
           <th class="border px-2 py-1 w-1/3">Summary</th>
-          <th class="border px-2 py-1">Sector / Industry</th>
+          <th class="border px-2 py-1">Clairfield Sector / Industry</th>
           <th class="border px-2 py-1">Location</th>
           <th class="border px-2 py-1">Completed</th>
           <th class="border px-2 py-1">Text</th>
@@ -98,13 +97,11 @@
         const acq = a.acquiror && a.acquiror !== 'N/A' ? escapeHtml(a.acquiror) : '';
         const seller = a.seller && a.seller !== 'N/A' ? escapeHtml(a.seller) : '';
         const target = a.target && a.target !== 'N/A' ? escapeHtml(a.target) : '';
-        if (a.transaction_type === 'Financing') {
-          if (acq) return `${seller || target} raised financing from ${acq}`;
-          return `${seller || target} raised financing`;
-        }
-        let text = `${acq}<br>acquired ${target}`;
-        if (seller && target && seller !== target) text += ` from ${seller}`;
-        return text;
+        const lines = [];
+        if (acq) lines.push(`<div class="font-bold text-lg">${acq}</div>`);
+        if (target) lines.push(`<div class="font-bold text-lg">${target}</div>`);
+        if (seller && seller !== target) lines.push(`<div class="font-bold text-lg">${seller}</div>`);
+        return lines.join('');
       }
 
       const sectorIcons = {
@@ -160,11 +157,13 @@
           const tombstone = formatTombstone(a);
           const sectorHtml = formatSectorIndustry(a);
           const completedHtml = formatCompleted(a.completed);
+          const truncated = a.title.length > 60 ? a.title.slice(0, 60) + '...' : a.title;
+          const titleLink = `<a class="text-blue-600 underline" href="${a.link}" target="_blank">${escapeHtml(truncated)}</a>`;
+          const summary = `${escapeHtml(a.summary || '')}<br>${titleLink}`;
           tr.innerHTML =
             `<td class="border px-2 py-1">${idx + 1}</td>` +
-            `<td class="border px-2 py-1"><a class="text-blue-600 underline" href="${a.link}" target="_blank">${a.title}</a></td>` +
             `<td class="border px-2 py-1">${tombstone}</td>` +
-            `<td class="border px-2 py-1 w-1/3">${a.summary || ''}</td>` +
+            `<td class="border px-2 py-1 w-1/3">${summary}</td>` +
             `<td class="border px-2 py-1">${sectorHtml}</td>` +
             `<td class="border px-2 py-1">${a.location || ''}</td>` +
             `<td class="border px-2 py-1">${completedHtml}</td>` +
@@ -189,11 +188,20 @@
           if (!values.length) return;
           const label = document.createElement('span');
           label.className = 'font-semibold mr-2';
-          label.textContent = field.charAt(0).toUpperCase() + field.slice(1) + ':';
+          if (field === 'sector') {
+            label.textContent = 'Clairfield Sector:';
+          } else {
+            label.textContent = field.charAt(0).toUpperCase() + field.slice(1) + ':';
+          }
           container.appendChild(label);
           values.slice(0, 10).forEach(v => {
             const pill = document.createElement('span');
-            pill.textContent = v;
+            if (field === 'sector') {
+              const icon = sectorIcons[v] || '🏢';
+              pill.innerHTML = `${icon} ${v}`;
+            } else {
+              pill.textContent = v;
+            }
             pill.dataset.field = field;
             pill.dataset.value = v;
             pill.className = 'cursor-pointer bg-gray-200 rounded-full px-2 py-1 text-sm';


### PR DESCRIPTION
## Summary
- tweak enriched database table to put Deal column first
- drop separate Title column and show a truncated link below the summary
- show Clairfield Sector header and icons in summary pills
- bold tombstone entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841dbc9b2b883318ff26d1b8e5007ee