### PR TITLE
Add extraction of deal value and improved location

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,20 @@ async function initDb() {
     );
   }
 
+  const valRow = await configDb.get(
+    'SELECT COUNT(*) as count FROM prompts WHERE name = ?',
+    ['extractValueLocation']
+  );
+  if (valRow.count === 0) {
+    await configDb.run(
+      'INSERT INTO prompts (name, template) VALUES (?, ?)',
+      [
+        'extractValueLocation',
+        'Extract the transaction value in US dollars from the article text if mentioned. If none is present respond with "undisclosed". Review the provided location "{location}" and return a more complete location including country if possible. Respond with JSON {"dealValue":"...","location":"..."}. Text: "{text}"'
+      ]
+    );
+  }
+
   const aeInfo = await db.all('PRAGMA table_info(article_enrichments)');
   const hasBody = aeInfo.some(r => r.name === 'body');
   if (!hasBody) {

--- a/lib/enrichment/extractValueAndLocation.js
+++ b/lib/enrichment/extractValueAndLocation.js
@@ -1,0 +1,63 @@
+const { getPrompt } = require('../prompts');
+const appendLog = require('./appendLog');
+
+const DEFAULT_TEMPLATE = `Extract the transaction value in US dollars from the article text if mentioned. If no value is mentioned, respond with "undisclosed". Also review the provided location "{location}" and return a more complete location including country if possible. Respond with JSON {"dealValue":"...","location":"..."}. Text: "{text}"`;
+
+async function extractValueAndLocation(articleDb, configDb, openai, id) {
+  const row = await articleDb.get(
+    'SELECT body, location FROM article_enrichments WHERE article_id = ?',
+    [id]
+  );
+  if (!row || !row.body) {
+    throw new Error('Article text not found');
+  }
+
+  const template = await getPrompt(
+    configDb,
+    'extractValueLocation',
+    DEFAULT_TEMPLATE
+  );
+  const prompt = template
+    .replace('{text}', row.body)
+    .replace('{location}', row.location || '');
+
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0
+  });
+
+  const output = resp.choices[0].message.content.trim();
+  let dealValue = 'undisclosed';
+  let location = row.location || '';
+  try {
+    const parsed = JSON.parse(output);
+    if (parsed.dealValue) dealValue = parsed.dealValue;
+    if (parsed.location) location = parsed.location;
+  } catch (e) {
+    // ignore parse errors
+  }
+
+  await articleDb.run(
+    `INSERT INTO article_enrichments (article_id, deal_value, location)
+       VALUES (?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET deal_value = excluded.deal_value, location = excluded.location`,
+    [id, dealValue, location]
+  );
+
+  await appendLog(articleDb, id, `Extracted value "${dealValue}" and location "${location}"`);
+
+  const row2 = await articleDb.get(
+    'SELECT completed FROM article_enrichments WHERE article_id = ?',
+    [id]
+  );
+  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
+  if (!completed.includes('value')) completed.push('value');
+  await articleDb.run('UPDATE article_enrichments SET completed = ? WHERE article_id = ?', [completed.join(','), id]);
+
+  await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
+
+  return { dealValue, location, prompt, output, completed: completed.join(',') };
+}
+
+module.exports = extractValueAndLocation;

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -2,6 +2,7 @@ const fetchAndStoreBody = require('./fetchAndStoreBody');
 const extractDateLocation = require('./extractDateLocation');
 const extractParties = require('./extractParties');
 const summarizeArticle = require('./summarizeArticle');
+const extractValueAndLocation = require('./extractValueAndLocation');
 
 module.exports = (articleDb, configDb, openai) => {
   return async function processArticle(id) {
@@ -11,5 +12,6 @@ module.exports = (articleDb, configDb, openai) => {
     }
     await extractParties(articleDb, configDb, openai, id);
     await summarizeArticle(articleDb, configDb, openai, id);
+    await extractValueAndLocation(articleDb, configDb, openai, id);
   };
 };

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -211,6 +211,19 @@ router.post('/:id/summarize', async (req, res) => {
   }
 });
 
+// Extract deal value from the full text and improve location using GPT
+const extractValueAndLocation = require('../lib/enrichment/extractValueAndLocation');
+router.post('/:id/extract-value-location', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await extractValueAndLocation(db, configDb, openai, id);
+    res.json({ success: true, ...result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to extract value/location' });
+  }
+});
+
 // Semantic search using OpenAI embeddings
 router.get('/semantic-search', async (req, res) => {
   const query = (req.query.q || '').trim();

--- a/test/enrichment/extractValueLocation.test.js
+++ b/test/enrichment/extractValueLocation.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const extractValueAndLocation = require('../../lib/enrichment/extractValueAndLocation');
+
+function createArticleDb(initialLocation = 'Paris') {
+  const store = { location: initialLocation, completed: '' };
+  return {
+    get: async (sql) => {
+      if (sql.includes('body, location')) {
+        return { body: 'body text', location: store.location };
+      }
+      if (sql.includes('SELECT completed')) {
+        return { completed: store.completed };
+      }
+      return null;
+    },
+    run: async (sql, params) => {
+      if (sql.startsWith('INSERT INTO article_enrichments')) {
+        store.dealValue = params[1];
+        store.location = params[2];
+      } else if (sql.startsWith('UPDATE article_enrichments SET completed')) {
+        store.completed = params[0];
+      }
+      return { changes: 1 };
+    }
+  };
+}
+
+const mockConfigDb = {
+  get: async () => ({}),
+  run: async () => {}
+};
+
+test('extracts deal value and updates location', async () => {
+  const mockOpenAI = {
+    chat: {
+      completions: {
+        create: async () => ({
+          choices: [{ message: { content: '{"dealValue":"$100m","location":"Paris, France"}' } }]
+        })
+      }
+    }
+  };
+  const db = createArticleDb();
+  const result = await extractValueAndLocation(db, mockConfigDb, mockOpenAI, 1);
+  assert.equal(result.dealValue, '$100m');
+  assert.equal(result.location, 'Paris, France');
+});
+
+test('handles invalid JSON output', async () => {
+  const mockOpenAI = {
+    chat: { completions: { create: async () => ({ choices: [{ message: { content: 'invalid' } }] }) } }
+  };
+  const db = createArticleDb('Toronto');
+  const result = await extractValueAndLocation(db, mockConfigDb, mockOpenAI, 2);
+  assert.equal(result.dealValue, 'undisclosed');
+  assert.equal(result.location, 'Toronto');
+});


### PR DESCRIPTION
## Summary
- add GPT-based extraction for deal value and location refinement
- hook new enrichment step into pipeline and expose API endpoint
- register new default prompt
- add tests for the value/location extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841dff1454483318e59485d9f6bb79c