### PR TITLE
Enhance tombstone display logic

### DIFF
--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -9,12 +9,38 @@ export function createTombstone(article) {
   const txType = article.transaction_type && article.transaction_type !== 'N/A'
     ? escapeHtml(article.transaction_type)
     : '';
+  const location = article.location && article.location !== 'N/A' ? escapeHtml(article.location) : '';
 
-  const lines = [];
-  if (acq) lines.push(`<div class="font-bold">${acq}</div>`);
-  if (target) lines.push(`<div class="font-bold">${target}</div>`);
-  if (seller && seller !== target) lines.push(`<div class="font-bold">${seller}</div>`);
-  if (txType) lines.push(`<div class="text-xs mt-1">${txType}</div>`);
+  const bodyLines = [];
+  if (txType === 'M&A') {
+    if (acq) bodyLines.push(`<div class="font-bold text-center">${acq}</div>`);
+    if (target || acq) bodyLines.push('<div class="text-center">acquired</div>');
+    if (target) bodyLines.push(`<div class="font-bold text-center">${target}</div>`);
+    if (seller && seller !== target) {
+      bodyLines.push('<div class="text-center">from</div>');
+      bodyLines.push(`<div class="font-bold text-center">${seller}</div>`);
+    }
+  } else if (txType === 'Financing') {
+    if (seller) bodyLines.push(`<div class="font-bold text-center">${seller}</div>`);
+    bodyLines.push('<div class="text-center">raised financing</div>');
+    if (acq) {
+      bodyLines.push('<div class="text-center">from</div>');
+      bodyLines.push(`<div class="font-bold text-center">${acq}</div>`);
+    }
+  } else {
+    if (acq) bodyLines.push(`<div class="font-bold text-center">${acq}</div>`);
+    if (target) bodyLines.push(`<div class="font-bold text-center">${target}</div>`);
+    if (seller && seller !== target) bodyLines.push(`<div class="font-bold text-center">${seller}</div>`);
+  }
 
-  return `<div class="flex flex-col items-center p-2 border rounded bg-gray-50">${lines.join('')}</div>`;
+  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}</div>`;
+  const footer = location ? `<div class="text-xs text-center w-full">${location}</div>` : '<div class="text-xs text-center w-full">&nbsp;</div>';
+
+  return (
+    `<div class="flex flex-col justify-between items-center p-2 border rounded bg-gray-50 w-48 h-40">` +
+    header +
+    `<div class="flex flex-col items-center flex-grow justify-center space-y-1">${bodyLines.join('')}</div>` +
+    footer +
+    `</div>`
+  );
 }


### PR DESCRIPTION
## Summary
- update the tombstone generator to display transaction type and location
- add logic for M&A vs Financing wording
- ensure container has consistent sizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841e4ad7da48331bb0ab6c3773e7647