### PR TITLE
Add sector counts and deal values

### DIFF
--- a/public/enriched.html
+++ b/public/enriched.html
@@ -60,6 +60,7 @@
           <th class="border px-2 py-1 w-1/3">Summary</th>
           <th class="border px-2 py-1">Clairfield Sector / Industry</th>
           <th class="border px-2 py-1">Location</th>
+          <th class="border px-2 py-1">Deal Size</th>
           <th class="border px-2 py-1">Completed</th>
           <th class="border px-2 py-1">Text</th>
         </tr>
@@ -155,6 +156,7 @@
             `<td class="border px-2 py-1 w-1/3">${summary}</td>` +
             `<td class="border px-2 py-1">${sectorHtml}</td>` +
             `<td class="border px-2 py-1">${a.location || ''}</td>` +
+            `<td class="border px-2 py-1">${a.deal_value || ''}</td>` +
             `<td class="border px-2 py-1">${completedHtml}</td>` +
             `<td class="border px-2 py-1"><div class="article-body ${hiddenClass}">${bodyHtml}</div></td>`;
           tbody.appendChild(tr);
@@ -165,12 +167,16 @@
       function updateSummary() {
         const container = document.getElementById('summaryPills');
         container.innerHTML = '';
+        const sectorCounts = {};
+        allArticles.forEach(a => {
+          if (a.sector) sectorCounts[a.sector] = (sectorCounts[a.sector] || 0) + 1;
+        });
         const groups = {
+          sector: Object.keys(sectorCounts),
           acquiror: [...new Set(allArticles.map(a => a.acquiror).filter(Boolean))],
           seller: [...new Set(allArticles.map(a => a.seller).filter(Boolean))],
           target: [...new Set(allArticles.map(a => a.target).filter(Boolean))],
           location: [...new Set(allArticles.map(a => a.location).filter(Boolean))],
-          sector: [...new Set(allArticles.map(a => a.sector).filter(Boolean))],
           industry: [...new Set(allArticles.map(a => a.industry).filter(Boolean))]
         };
         Object.entries(groups).forEach(([field, values]) => {
@@ -187,7 +193,8 @@
             const pill = document.createElement('span');
             if (field === 'sector') {
               const icon = sectorIcons[v] || '🏢';
-              pill.innerHTML = `${icon} ${v}`;
+              const count = sectorCounts[v] || 0;
+              pill.innerHTML = `${icon} ${v} (${count})`;
             } else {
               pill.textContent = v;
             }

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -135,7 +135,7 @@ router.get('/enriched-list', async (req, res) => {
   const rows = await db.all(
     `SELECT a.id, a.title, a.description, a.time, a.link,
             ae.body, ae.acquiror, ae.seller, ae.target,
-            ae.location, ae.article_date, ae.completed,
+            ae.deal_value, ae.location, ae.article_date, ae.completed,
             ae.transaction_type, ae.log,
             ae.summary, ae.sector, ae.industry
        FROM articles a


### PR DESCRIPTION
## Summary
- include `deal_value` field in enriched article route
- show deal size column in `enriched.html`
- display Clairfield sector first with counts in pills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841e52381c08331938129c1bc142cf2