### PR TITLE
Make summarization and location prompts editable

### DIFF
--- a/public/manage.html
+++ b/public/manage.html
@@ -78,8 +78,22 @@
     <div class="mb-4">
       <label for="extractPartiesPrompt" class="block mb-1 font-medium">Extract Parties Prompt</label>
       <textarea id="extractPartiesPrompt" class="border p-2 w-full h-32"></textarea>
-      <button id="savePromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
-      <div id="promptStatus" class="text-sm mt-1"></div>
+      <button id="savePartiesPromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
+      <div id="partiesPromptStatus" class="text-sm mt-1"></div>
+    </div>
+
+    <div class="mb-4">
+      <label for="summarizeArticlePrompt" class="block mb-1 font-medium">Summarize Article Prompt</label>
+      <textarea id="summarizeArticlePrompt" class="border p-2 w-full h-32"></textarea>
+      <button id="saveSummarizePromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
+      <div id="summarizePromptStatus" class="text-sm mt-1"></div>
+    </div>
+
+    <div class="mb-4">
+      <label for="extractValueLocationPrompt" class="block mb-1 font-medium">Value &amp; Location Prompt</label>
+      <textarea id="extractValueLocationPrompt" class="border p-2 w-full h-32"></textarea>
+      <button id="saveValuePromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
+      <div id="valuePromptStatus" class="text-sm mt-1"></div>
     </div>
 
     <script>
@@ -233,26 +247,54 @@
         loadFilters();
       });
 
-      async function loadPrompt() {
-        const res = await fetch('/prompts/extractParties');
-        if (!res.ok) return;
-        const { template } = await res.json();
-        document.getElementById('extractPartiesPrompt').value = template || '';
+      async function loadPrompts() {
+        const map = {
+          extractPartiesPrompt: 'extractParties',
+          summarizeArticlePrompt: 'summarizeArticle',
+          extractValueLocationPrompt: 'extractValueLocation'
+        };
+        for (const [id, name] of Object.entries(map)) {
+          const res = await fetch(`/prompts/${name}`);
+          if (!res.ok) continue;
+          const { template } = await res.json();
+          const el = document.getElementById(id);
+          if (el) el.value = template || '';
+        }
       }
 
-      document.getElementById('savePromptBtn').addEventListener('click', async () => {
+      document.getElementById('savePartiesPromptBtn').addEventListener('click', async () => {
         const template = document.getElementById('extractPartiesPrompt').value;
         await fetch('/prompts/extractParties', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ template })
         });
-        document.getElementById('promptStatus').textContent = 'Saved';
+        document.getElementById('partiesPromptStatus').textContent = 'Saved';
+      });
+
+      document.getElementById('saveSummarizePromptBtn').addEventListener('click', async () => {
+        const template = document.getElementById('summarizeArticlePrompt').value;
+        await fetch('/prompts/summarizeArticle', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ template })
+        });
+        document.getElementById('summarizePromptStatus').textContent = 'Saved';
+      });
+
+      document.getElementById('saveValuePromptBtn').addEventListener('click', async () => {
+        const template = document.getElementById('extractValueLocationPrompt').value;
+        await fetch('/prompts/extractValueLocation', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ template })
+        });
+        document.getElementById('valuePromptStatus').textContent = 'Saved';
       });
 
       loadSources();
       loadFilters();
-      loadPrompt();
+      loadPrompts();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow editing summarization and value/location prompts on the manage page
- add JS logic to load and save these prompts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68420861190483318ecde80dfb9344a1