### PR TITLE
Add This Week in M&A page

### DIFF
--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>This Week in M&A</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">This Week in M&A</h1>
+
+    <div class="mb-4 space-x-2">
+      <input id="queryInput" class="border px-2 py-1" placeholder="Search text" />
+      <input id="thresholdInput" class="border px-2 py-1 w-24" type="number" step="0.01" min="0" max="1" value="0.8" />
+      <button id="searchBtn" class="bg-blue-500 text-white px-3 py-1 rounded">Search</button>
+    </div>
+
+    <div class="mb-4 space-x-2">
+      <input id="filterInput" class="border px-2 py-1" placeholder="Filter keywords" />
+    </div>
+
+    <div id="summaryPills" class="mb-4 flex flex-wrap gap-2"></div>
+    <div class="mb-4 space-x-2">
+      <label>Date Range:
+        <select id="dateSelect" class="border px-2 py-1">
+          <option value="week" selected>This Week</option>
+          <option value="month">This Month</option>
+          <option value="year">This Year</option>
+        </select>
+      </label>
+    </div>
+
+    <table class="table-auto w-full border-collapse mb-4">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">Title</th>
+          <th class="border px-2 py-1">Description</th>
+          <th class="border px-2 py-1">Score</th>
+          <th class="border px-2 py-1">Link</th>
+        </tr>
+      </thead>
+      <tbody id="resultsBody"></tbody>
+    </table>
+
+
+    <div class="mb-4 space-x-2">
+      <label>Completeness:
+        <select id="levelSelect" class="border px-2 py-1">
+          <option value="all">All</option>
+          <option value="full">Fully Complete</option>
+          <option value="partial">Incomplete</option>
+        </select>
+      </label>
+      <button id="loadBtn" class="bg-green-500 text-white px-3 py-1 rounded">Load Articles</button>
+    </div>
+
+    <div id="stats" class="mb-2 text-sm"></div>
+
+    <table class="table-auto w-full border-collapse">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">#</th>
+          <th class="border px-2 py-1">Deal</th>
+          <th class="border px-2 py-1 w-1/3">Summary</th>
+          <th class="border px-2 py-1">Clairfield Sector / Industry</th>
+          <th class="border px-2 py-1">Location</th>
+          <th class="border px-2 py-1">Deal Size</th>
+        </tr>
+      </thead>
+      <tbody id="articlesBody"></tbody>
+    </table>
+    <script type="module">
+      import { createTombstone, escapeHtml } from './tombstone.js';
+
+      function formatBody(text) {
+        const limit = 200;
+        text = text.replace(/\n+/g, '\n');
+        if (text.length <= limit) {
+          return `<div class="text-container"><span class="full">${escapeHtml(text)}</span></div>`;
+        }
+        const preview = escapeHtml(text.slice(0, limit)) + '...';
+        return `<div class="text-container"><span class="preview">${preview}</span><span class="full hidden">${escapeHtml(text)}</span> <a href="#" class="seeMore text-blue-600 underline">See more</a></div>`;
+      }
+
+      function initToggles() {
+        document.querySelectorAll('.seeMore').forEach(link => {
+          link.onclick = e => {
+            e.preventDefault();
+            const container = e.target.closest('.text-container');
+            container.querySelector('.preview').classList.toggle('hidden');
+            container.querySelector('.full').classList.toggle('hidden');
+            e.target.textContent = container.querySelector('.full').classList.contains('hidden') ? 'See more' : 'Hide';
+          };
+        });
+      }
+
+
+
+      const sectorIcons = {
+        Healthcare: '⚕️',
+        Energy: '⚡',
+        Industrials: '🏭',
+        Consumer: '🛒',
+        'Financial Services': '💰',
+        TMT: '💻'
+      };
+
+      function formatSectorIndustry(a) {
+        if (!a.sector && !a.industry) return '';
+        const icon = sectorIcons[a.sector] || '🏢';
+        const sector = a.sector ? escapeHtml(a.sector) : '';
+        const industry = a.industry ? escapeHtml(a.industry) : '';
+        return `${icon} ${sector}<br>${industry}`;
+      }
+
+        const types = ['body', 'embedding', 'date', 'location', 'parties', 'summary'];
+        const done = str ? str.split(',') : [];
+        return types
+          .map(t => `<div>${t}: ${done.includes(t) ? '✓' : ''}</div>`)
+          .join('');
+      }
+
+      let allArticles = [];
+      const filters = { keyword: '', sector: '', industry: '', dealValue: '', dateRange: 'week' };
+
+      function parseDealValueMillions(str) {
+        if (!str) return null;
+        const lower = str.toLowerCase();
+        if (lower.includes('undisclosed')) return null;
+        const m = str.replace(/[, ]/g, '').match(/(\d+(?:\.\d+)?)/);
+        if (!m) return null;
+        let num = parseFloat(m[1]);
+        if (/b|bn|billion/i.test(lower)) num *= 1000;
+        return num;
+      }
+
+      function valueBucket(str) {
+        const val = parseDealValueMillions(str);
+        if (val == null) return 'Undisclosed';
+        if (val < 20) return '0-20M';
+        if (val < 100) return '20-100M';
+        if (val < 1000) return '100M-1B';
+        return '1B+';
+      }
+
+      function getRows(ignore) {
+        const kw = filters.keyword.toLowerCase();
+        return allArticles.filter(a => {
+          if (ignore !== 'sector' && filters.sector && a.sector !== filters.sector) return false;
+          if (ignore !== 'industry' && filters.industry && a.industry !== filters.industry) return false;
+          if (ignore !== 'dealValue' && filters.dealValue && a.valueBucket !== filters.dealValue) return false;
+          if (filters.dateRange) {
+            const d = new Date(a.article_date);
+            if (isFinite(d)) {
+              const now = new Date();
+              let start, end;
+              if (filters.dateRange === 'week') {
+                const day = now.getDay();
+                const diff = (day === 0 ? -6 : 1) - day;
+                start = new Date(now);
+                start.setHours(0,0,0,0);
+                start.setDate(start.getDate() + diff);
+                end = new Date(start);
+                end.setDate(start.getDate() + 7);
+              } else if (filters.dateRange === 'month') {
+                start = new Date(now.getFullYear(), now.getMonth(), 1);
+                end = new Date(now.getFullYear(), now.getMonth()+1, 1);
+              } else if (filters.dateRange === 'year') {
+                start = new Date(now.getFullYear(), 0, 1);
+                end = new Date(now.getFullYear()+1, 0, 1);
+              }
+              if (start && end && (d < start || d >= end)) return false;
+            }
+          }
+          if (kw) {
+            const text = `${a.title} ${a.description || ''} ${a.body || ''}`.toLowerCase();
+            if (!text.includes(kw)) return false;
+          }
+          return true;
+        });
+      }
+
+      function renderArticles() {
+        const tbody = document.getElementById('articlesBody');
+        tbody.innerHTML = '';
+        const rows = getRows();
+
+        rows.forEach((a, idx) => {
+          const tr = document.createElement('tr');
+          const tombstone = createTombstone(a);
+          const sectorHtml = formatSectorIndustry(a);
+          const truncated = a.title.length > 60 ? a.title.slice(0, 60) + '...' : a.title;
+          const titleLink = `<a class="text-blue-600 underline" href="${a.link}" target="_blank">${escapeHtml(truncated)}</a>`;
+          const summary = `${escapeHtml(a.summary || '')}<br>${titleLink}`;
+          tr.innerHTML =
+            `<td class="border px-2 py-1">${idx + 1}</td>` +
+            `<td class="border px-2 py-1">${tombstone}</td>` +
+            `<td class="border px-2 py-1 w-1/3">${summary}</td>` +
+            `<td class="border px-2 py-1">${sectorHtml}</td>` +
+            `<td class="border px-2 py-1">${a.location || ''}</td>` +
+            `<td class="border px-2 py-1">${a.deal_value || ''}</td>` +
+          tbody.appendChild(tr);
+        });
+        initToggles();
+      }
+
+      function updateSummary() {
+        const container = document.getElementById('summaryPills');
+    <div class="mb-4 space-x-2">
+      <label>Date Range:
+        <select id="dateSelect" class="border px-2 py-1">
+          <option value="week" selected>This Week</option>
+          <option value="month">This Month</option>
+          <option value="year">This Year</option>
+        </select>
+      </label>
+    </div>
+        container.innerHTML = '';
+
+        const sectorCounts = {};
+        allArticles.forEach(a => {
+          if (a.sector) sectorCounts[a.sector] = (sectorCounts[a.sector] || 0) + 1;
+        });
+
+        const industryCounts = {};
+        getRows('industry').forEach(a => {
+          if (a.industry) industryCounts[a.industry] = (industryCounts[a.industry] || 0) + 1;
+        });
+
+        const valueCounts = {};
+        getRows('dealValue').forEach(a => {
+          const b = a.valueBucket;
+          valueCounts[b] = (valueCounts[b] || 0) + 1;
+        });
+
+        const groups = {
+          sector: Object.keys(sectorCounts),
+          industry: Object.keys(industryCounts),
+          dealValue: ['0-20M','20-100M','100M-1B','1B+','Undisclosed'].filter(b => valueCounts[b])
+        };
+        Object.entries(groups).forEach(([field, values]) => {
+          if (!values.length) return;
+          const label = document.createElement('span');
+          label.className = 'font-semibold mr-2';
+          if (field === 'sector') {
+            label.textContent = 'Clairfield Sector:';
+          } else {
+            label.textContent = field === 'dealValue' ? 'Deal Value:' : 'Industry:';
+          }
+          container.appendChild(label);
+          values.slice(0, 10).forEach(v => {
+            const pill = document.createElement('span');
+            if (field === 'sector') {
+              const icon = sectorIcons[v] || '🏢';
+              const count = sectorCounts[v] || 0;
+              pill.innerHTML = `${icon} ${v} (${count})`;
+            } else if (field === 'industry') {
+              const count = industryCounts[v] || 0;
+              pill.textContent = `${v} (${count})`;
+            } else {
+              const count = valueCounts[v] || 0;
+              pill.textContent = `${v} (${count})`;
+            }
+            pill.dataset.field = field;
+            pill.dataset.value = v;
+            pill.className = 'cursor-pointer rounded-full px-2 py-1 text-sm';
+            if (filters[field] === v) {
+              pill.classList.add('bg-blue-500', 'text-white');
+            } else {
+              pill.classList.add('bg-gray-200');
+            }
+            pill.addEventListener('click', () => {
+              const cur = filters[field] === v;
+              filters[field] = cur ? '' : v;
+              updateSummary();
+              renderArticles();
+            });
+            container.appendChild(pill);
+          });
+          const spacer = document.createElement('span');
+          spacer.className = 'w-full';
+          container.appendChild(spacer);
+        });
+      }
+
+      async function loadArticles() {
+        const level = document.getElementById('levelSelect').value;
+        const res = await fetch('/articles/enriched-list?level=' + level);
+        const data = await res.json();
+        allArticles = data.articles.map(a => ({ ...a, valueBucket: valueBucket(a.deal_value) }));
+        document.getElementById('stats').textContent = `Total: ${data.stats.total} | Fully Complete: ${data.stats.full} | Incomplete: ${data.stats.partial}`;
+        updateSummary();
+        renderArticles();
+      }
+
+      function addRow(a, matched) {
+        const tr = document.createElement('tr');
+        if (matched) tr.classList.add('bg-green-200');
+        tr.innerHTML =
+          `<td class="border px-2 py-1">${a.title}</td>` +
+          `<td class="border px-2 py-1">${a.description || ''}</td>` +
+          `<td class="border px-2 py-1">${a.score.toFixed(3)}</td>` +
+          `<td class="border px-2 py-1"><a href="${a.link}" target="_blank" class="text-blue-600 underline">Link</a></td>`;
+        return tr;
+      }
+
+      async function doSearch() {
+        const q = document.getElementById('queryInput').value.trim();
+        const threshold = parseFloat(document.getElementById('thresholdInput').value) || 0.8;
+        if (!q) return;
+        const params = new URLSearchParams({ q, threshold });
+        const res = await fetch('/articles/semantic-search?' + params.toString());
+        const data = await res.json();
+        const tbody = document.getElementById('resultsBody');
+        tbody.innerHTML = '';
+        (data.matches || []).forEach(a => tbody.appendChild(addRow(a, true)));
+        (data.others || []).forEach(a => tbody.appendChild(addRow(a, false)));
+      }
+
+      loadArticles();
+      document.getElementById('loadBtn').addEventListener('click', loadArticles);
+      document.getElementById('searchBtn').addEventListener('click', doSearch);
+      document.getElementById('filterInput').addEventListener('input', e => {
+        filters.keyword = e.target.value.trim();
+        updateSummary();
+        renderArticles();
+      });
+      document.getElementById("dateSelect").addEventListener("change", e => {
+        filters.dateRange = e.target.value;
+        renderArticles();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new page `public/thisweek.html`
- remove the navigation menu on this page
- drop the `Completed` and `Text` columns
- add a date range filter preset to the current week

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6842f84c65c083318a2c05f5bda09414