### PR TITLE
Add streaming logs and earliest stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,8 +221,8 @@ app.get('/stats', async (req, res) => {
       } catch (e) {}
     });
 
-    const row = await db.get('SELECT COUNT(*) as total, MAX(created_at) as latest FROM articles');
-    res.json({ total: row.total, latest: row.latest, bySource });
+    const row = await db.get('SELECT COUNT(*) as total, MAX(created_at) as latest, MIN(created_at) as earliest FROM articles');
+    res.json({ total: row.total, latest: row.latest, earliest: row.earliest, bySource });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to retrieve stats' });
@@ -356,6 +356,82 @@ app.get('/scrape-enrich', async (req, res) => {
     console.error(err);
     logs.push(`Error: ${err.message}`);
     res.status(500).json({ error: 'Full scrape failed', logs });
+  }
+});
+
+// Streaming version of the full pipeline using Server-Sent Events
+app.get('/scrape-enrich-stream', async (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  const logs = [];
+  const send = msg => res.write(`data: ${msg}\n\n`);
+
+  try {
+    const sources = await configDb.all('SELECT * FROM sources');
+    send(`Found ${sources.length} sources`);
+
+    let insertedTotal = 0;
+    let enrichedTotal = 0;
+
+    for (const source of sources) {
+      send(`Fetching ${source.base_url}`);
+      let articles;
+      try {
+        articles = await scrapeSource(source);
+        send(`Loaded ${articles.length} articles from ${source.base_url}`);
+      } catch (e) {
+        send(`Failed to fetch ${source.base_url}: ${e.message}`);
+        continue;
+      }
+
+      const insertPromises = articles.map(a =>
+        db.run(
+          'INSERT OR IGNORE INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, ?)',
+          [a.title, a.description, a.time, a.link, a.image]
+        )
+      );
+
+      const results = await Promise.all(insertPromises);
+      const inserted = results.reduce((acc, cur) => acc + cur.changes, 0);
+      const insertedIds = results.filter(r => r.changes > 0).map(r => r.lastID);
+      insertedTotal += inserted;
+      send(`Inserted ${inserted} new articles from ${source.base_url}`);
+
+      if (insertedIds.length) {
+        await runFilters(db, configDb, insertedIds, logs);
+        logs.forEach(send);
+        logs.length = 0;
+
+        const placeholders = insertedIds.map(() => '?').join(',');
+        const rows = await db.all(
+          `SELECT DISTINCT article_id FROM article_filter_matches WHERE article_id IN (${placeholders})`,
+          insertedIds
+        );
+        const matchedIds = rows.map(r => r.article_id);
+        for (const id of matchedIds) {
+          try {
+            await processArticle(id);
+            enrichedTotal++;
+            send(`Enriched article ${id}`);
+          } catch (e) {
+            send(`Failed to enrich article ${id}: ${e.message}`);
+          }
+        }
+      }
+    }
+
+    send(`Inserted total ${insertedTotal} new articles`);
+    send(`Enriched total ${enrichedTotal} articles`);
+    res.write(`event: done\ndata: ${JSON.stringify({ inserted: insertedTotal, enriched: enrichedTotal })}\n\n`);
+    res.end();
+  } catch (err) {
+    console.error(err);
+    send(`Error: ${err.message}`);
+    res.write(`event: done\ndata: ${JSON.stringify({ error: 'Full scrape failed' })}\n\n`);
+    res.end();
   }
 });
 

--- a/public/index.html
+++ b/public/index.html
@@ -135,7 +135,7 @@
         for (const [src, count] of Object.entries(data.bySource)) {
           sourceParts += `${src}: ${count} articles `;
         }
-        div.textContent = `Total: ${data.total} | Latest: ${data.latest || 'N/A'} | ${sourceParts}`;
+        div.textContent = `Total: ${data.total} | Latest: ${data.latest || 'N/A'} | Earliest: ${data.earliest || 'N/A'} | ${sourceParts}`;
       }
 
       document.getElementById('scrapeBtn').addEventListener('click', async () => {
@@ -167,18 +167,33 @@
         loadArticles();
       });
 
-      document.getElementById('fullRunBtn').addEventListener('click', async () => {
+      document.getElementById('fullRunBtn').addEventListener('click', () => {
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
         log.textContent = '';
         div.textContent = 'Running full pipeline...';
 
-        const res = await fetch('/scrape-enrich');
-        const data = await res.json();
-        div.textContent = `Inserted ${data.inserted} new, enriched ${data.enriched}`;
-        log.textContent = (data.logs || []).join('\n');
-        loadArticles();
-        loadStats();
+        const es = new EventSource('/scrape-enrich-stream');
+        es.onmessage = e => {
+          log.textContent += e.data + '\n';
+          log.scrollTop = log.scrollHeight;
+        };
+        es.addEventListener('done', e => {
+          es.close();
+          try {
+            const data = JSON.parse(e.data);
+            if (!data.error) {
+              div.textContent = `Inserted ${data.inserted} new, enriched ${data.enriched}`;
+            } else {
+              div.textContent = 'Error: ' + data.error;
+            }
+          } catch {
+            div.textContent = 'Completed';
+          }
+          loadArticles();
+          loadStats();
+        });
+        es.onerror = () => es.close();
       });
 
       loadSources();


### PR DESCRIPTION
## Summary
- show earliest article time on the homepage
- stream log output for the full pipeline via Server‑Sent Events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6842fb3048ac83319285df08bb084a9d