### PR TITLE
Embed-based sector classification

### DIFF
--- a/lib/classifySector.js
+++ b/lib/classifySector.js
@@ -1,0 +1,66 @@
+const CLAIRFIELD_SECTORS = [
+  'Business services',
+  'Consumer goods & retail',
+  'Energy, cleantech & resources',
+  'Healthcare',
+  'Industrials',
+  'Software, tech & digital'
+];
+
+function cosineSimilarity(a, b) {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    dot += x * y;
+    normA += x * x;
+    normB += y * y;
+  }
+  if (!normA || !normB) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function classifySectorFromVectors(articleVec, sectorVectors, names = CLAIRFIELD_SECTORS) {
+  if (!articleVec || !Array.isArray(sectorVectors)) return '';
+  let best = '';
+  let bestScore = -Infinity;
+  for (let i = 0; i < names.length; i++) {
+    const vec = sectorVectors[i];
+    if (!vec) continue;
+    const score = cosineSimilarity(articleVec, vec);
+    if (score > bestScore) {
+      bestScore = score;
+      best = names[i];
+    }
+  }
+  return best;
+}
+
+let cachedSectorVectors = null;
+async function getSectorVectors(openai) {
+  if (cachedSectorVectors) return cachedSectorVectors;
+  if (!openai || !openai.embeddings || typeof openai.embeddings.create !== 'function') {
+    cachedSectorVectors = CLAIRFIELD_SECTORS.map(() => null);
+    return cachedSectorVectors;
+  }
+  const resp = await openai.embeddings.create({
+    model: 'text-embedding-ada-002',
+    input: CLAIRFIELD_SECTORS
+  });
+  cachedSectorVectors = resp.data.map(d => d.embedding);
+  return cachedSectorVectors;
+}
+
+async function classifySector(openai, articleVec) {
+  if (!articleVec) return '';
+  const sectorVecs = await getSectorVectors(openai);
+  return classifySectorFromVectors(articleVec, sectorVecs, CLAIRFIELD_SECTORS);
+}
+
+module.exports = {
+  CLAIRFIELD_SECTORS,
+  classifySectorFromVectors,
+  classifySector
+};

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -1,13 +1,22 @@
 const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
+const { classifySector } = require('../classifySector');
 
 const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Respond with JSON {"summary":"...","sector":"...","industry":"..."}. Text: "{text}"`;
 
 async function summarizeArticle(articleDb, configDb, openai, id) {
   const row = await articleDb.get(
-    'SELECT body FROM article_enrichments WHERE article_id = ?',
+    'SELECT body, embedding FROM article_enrichments WHERE article_id = ?',
     [id]
   );
+  let embeddingVec = null;
+  if (row && row.embedding) {
+    try {
+      embeddingVec = JSON.parse(row.embedding);
+    } catch (e) {
+      // ignore parse error
+    }
+  }
   if (!row || !row.body) {
     throw new Error('Article text not found');
   }
@@ -27,16 +36,22 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
 
   const output = resp.choices[0].message.content.trim();
   let summary = '';
-  let sector = '';
   let industry = '';
+  let sector = '';
   try {
     const parsed = JSON.parse(output);
     if (parsed.summary) summary = parsed.summary;
-    if (parsed.sector) sector = parsed.sector;
-    if (parsed.clairfield_sector && !sector) sector = parsed.clairfield_sector;
     if (parsed.industry) industry = parsed.industry;
   } catch (e) {
     // ignore parse errors
+  }
+
+  if (!sector && embeddingVec) {
+    try {
+      sector = await classifySector(openai, embeddingVec);
+    } catch (e) {
+      sector = '';
+    }
   }
 
   await articleDb.run(

--- a/test/classifySector.test.js
+++ b/test/classifySector.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { classifySectorFromVectors } = require('../lib/classifySector');
+
+const sectors = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+// simple 2D vectors for ease of testing
+const sectorVecs = [
+  [1, 0],
+  [0, 1],
+  [-1, 0],
+  [0, -1],
+  [1, 1],
+  [-1, -1]
+];
+
+test('selects sector with highest cosine similarity', () => {
+  const articleVec = [0.9, 0.1];
+  const sector = classifySectorFromVectors(articleVec, sectorVecs, sectors);
+  assert.equal(sector, 'A');
+});
+
+test('returns empty string when vectors missing', () => {
+  const sector = classifySectorFromVectors(null, null, sectors);
+  assert.equal(sector, '');
+});


### PR DESCRIPTION
## Summary
- add `classifySector` utility to assign articles to one of six fixed Clairfield sectors using cosine similarity
- update `summarizeArticle` to compute sector from article embeddings
- test classification logic with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843024776608331a3cb281a936cf13c