### PR TITLE
Fix Clairfield sector icons

### DIFF
--- a/public/sectorIcons.js
+++ b/public/sectorIcons.js
@@ -1,10 +1,17 @@
 export const sectorIcons = {
+  // Clairfield sector names
+  "Business services": "\uD83D\uDCCA", // bar chart
+  "Consumer goods & retail": "\uD83D\uDED2", // shopping cart
+  "Energy, cleantech & resources": "\u26A1", // high voltage
+  "Healthcare": "\u2695\uFE0F", // medical symbol
+  "Industrials": "\uD83C\uDFED", // factory
+  "Software, tech & digital": "\uD83D\uDCBB", // laptop
+
+  // Legacy names used in older data
   "Business Services": "\uD83D\uDCCA", // bar chart
   "Consumer": "\uD83D\uDED2", // shopping cart
   "Energy": "\u26A1", // high voltage
   "Financial Services": "\uD83D\uDCB0", // money bag
-  "Healthcare": "\u2695\uFE0F", // medical symbol
-  "Industrials": "\uD83C\uDFED", // factory
   "Real Estate": "\uD83C\uDFE0", // house with garden
   "TMT": "\uD83D\uDCBB", // laptop
 };


### PR DESCRIPTION
## Summary
- ensure `sectorIcons.js` includes keys for Clairfield sector names so the UI shows unique icons for Consumer, Energy, Software and Business Services

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684304dd02288331ab67e9f2aa3abca2