### PR TITLE
Use table for enrichment steps

### DIFF
--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const cheerio = require('cheerio');
 const extractDateLocation = require('../extractDateLocation');
 const appendLog = require('./appendLog');
+const { markCompleted, getCompleted } = require('./steps');
 
 async function run(articleDb, configDb, id) {
   const article = await articleDb.get('SELECT link FROM articles WHERE id = ?', [id]);
@@ -63,18 +64,9 @@ async function run(articleDb, configDb, id) {
 
   await appendLog(articleDb, id, `Extracted date "${date}" and location "${location}"`);
 
-  const row2 = await articleDb.get(
-    'SELECT completed FROM article_enrichments WHERE article_id = ?',
-    [id]
-  );
-  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
-  if (date && !completed.includes('date')) completed.push('date');
-  if (location && !completed.includes('location')) completed.push('location');
-  await articleDb.run(
-    'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
-    [completed.join(','), id]
-  );
-
+  if (date) await markCompleted(articleDb, id, 'date');
+  if (location) await markCompleted(articleDb, id, 'location');
+  const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { date, location, completed: completed.join(',') };

--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -5,6 +5,7 @@ const {
 } = require('../extractParties');
 const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
+const { markCompleted, getCompleted } = require('./steps');
 
 async function extractParties(articleDb, configDb, openai, id) {
   const row = await articleDb.get(
@@ -38,14 +39,8 @@ async function extractParties(articleDb, configDb, openai, id) {
 
   await appendLog(articleDb, id, `Extracted parties a:${acquiror} s:${seller} t:${target} type:${transactionType}`);
 
-  const row2 = await articleDb.get('SELECT completed FROM article_enrichments WHERE article_id = ?', [id]);
-  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
-  if (!completed.includes('parties')) completed.push('parties');
-  await articleDb.run(
-    `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
-    [completed.join(','), id]
-  );
-
+  await markCompleted(articleDb, id, 'parties');
+  const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return {

--- a/lib/enrichment/extractValueAndLocation.js
+++ b/lib/enrichment/extractValueAndLocation.js
@@ -1,5 +1,6 @@
 const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
+const { markCompleted, getCompleted } = require('./steps');
 
 const DEFAULT_TEMPLATE = `Extract the transaction value in US dollars from the article text if mentioned. If no value is mentioned, respond with "undisclosed". Also review the provided location "{location}" and return a more complete location including country if possible. Respond with JSON {"dealValue":"...","location":"..."}. Text: "{text}"`;
 
@@ -47,14 +48,8 @@ async function extractValueAndLocation(articleDb, configDb, openai, id) {
 
   await appendLog(articleDb, id, `Extracted value "${dealValue}" and location "${location}"`);
 
-  const row2 = await articleDb.get(
-    'SELECT completed FROM article_enrichments WHERE article_id = ?',
-    [id]
-  );
-  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
-  if (!completed.includes('value')) completed.push('value');
-  await articleDb.run('UPDATE article_enrichments SET completed = ? WHERE article_id = ?', [completed.join(','), id]);
-
+  await markCompleted(articleDb, id, 'value');
+  const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { dealValue, location, prompt, output, completed: completed.join(',') };

--- a/lib/enrichment/fetchAndStoreBody.js
+++ b/lib/enrichment/fetchAndStoreBody.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 const appendLog = require('./appendLog');
+const { markCompleted, getCompleted } = require('./steps');
 
 async function fetchAndStoreBody(articleDb, configDb, openai, id) {
   const article = await articleDb.get('SELECT link FROM articles WHERE id = ?', [id]);
@@ -86,17 +87,16 @@ async function fetchAndStoreBody(articleDb, configDb, openai, id) {
     await appendLog(articleDb, id, 'Generated embedding');
   }
 
-  const row = await articleDb.get('SELECT completed, embedding FROM article_enrichments WHERE article_id = ?', [id]);
-  const completed = row && row.completed ? row.completed.split(',') : [];
-  if (!completed.includes('body')) completed.push('body');
-  if ((embeddingJson || row.embedding) && !completed.includes('embedding')) {
-    completed.push('embedding');
-  }
-  await articleDb.run(
-    `UPDATE article_enrichments SET completed = ? WHERE article_id = ?`,
-    [completed.join(','), id]
+  const row = await articleDb.get(
+    'SELECT embedding FROM article_enrichments WHERE article_id = ?',
+    [id]
   );
+  await markCompleted(articleDb, id, 'body');
+  if (embeddingJson || row.embedding) {
+    await markCompleted(articleDb, id, 'embedding');
+  }
 
+  const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { body: text, completed: completed.join(',') };

--- a/lib/enrichment/steps.js
+++ b/lib/enrichment/steps.js
@@ -1,0 +1,22 @@
+async function markCompleted(db, id, step) {
+  const row = await db.get(
+    'SELECT 1 FROM article_enrichment_steps WHERE article_id = ? AND step_name = ?',
+    [id, step]
+  );
+  if (!row) {
+    await db.run(
+      'INSERT INTO article_enrichment_steps (article_id, step_name) VALUES (?, ?)',
+      [id, step]
+    );
+  }
+}
+
+async function getCompleted(db, id) {
+  const rows = await db.all(
+    'SELECT step_name FROM article_enrichment_steps WHERE article_id = ?',
+    [id]
+  );
+  return rows.map(r => r.step_name);
+}
+
+module.exports = { markCompleted, getCompleted };

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -1,6 +1,7 @@
 const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
 const { classifySector } = require('../classifySector');
+const { markCompleted, getCompleted } = require('./steps');
 
 const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Respond with JSON {"summary":"...","sector":"...","industry":"..."}. Text: "{text}"`;
 
@@ -63,17 +64,8 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
 
   await appendLog(articleDb, id, `Summarized article with sector "${sector}"`);
 
-  const row2 = await articleDb.get(
-    'SELECT completed FROM article_enrichments WHERE article_id = ?',
-    [id]
-  );
-  const completed = row2 && row2.completed ? row2.completed.split(',') : [];
-  if (!completed.includes('summary')) completed.push('summary');
-  await articleDb.run(
-    'UPDATE article_enrichments SET completed = ? WHERE article_id = ?',
-    [completed.join(','), id]
-  );
-
+  await markCompleted(articleDb, id, 'summary');
+  const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
   return { summary, sector, industry, prompt, output, completed: completed.join(',') };


### PR DESCRIPTION
## Summary
- add `article_enrichment_steps` table and migrate data
- record enrichment progress in the new table
- update article routes to read from the steps table
- adjust enrichment tests for the new table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843124ede4c8331bb4e020091539ca2