### PR TITLE
Allow single-step pipeline execution

### DIFF
--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -5,13 +5,41 @@ const summarizeArticle = require('./summarizeArticle');
 const extractValueAndLocation = require('./extractValueAndLocation');
 
 module.exports = (articleDb, configDb, openai) => {
-  return async function processArticle(id) {
-    const bodyRes = await fetchAndStoreBody(articleDb, configDb, openai, id);
-    if (bodyRes && bodyRes.body) {
-      await extractDateLocation(articleDb, configDb, id);
+  const stepFns = {
+    body: id => fetchAndStoreBody(articleDb, configDb, openai, id),
+    date: id => extractDateLocation(articleDb, configDb, id),
+    parties: id => extractParties(articleDb, configDb, openai, id),
+    summary: id => summarizeArticle(articleDb, configDb, openai, id),
+    value: id => extractValueAndLocation(articleDb, configDb, openai, id)
+  };
+
+  const allSteps = Object.keys(stepFns);
+
+  return async function processArticle(id, steps = allSteps) {
+    let bodyRes = null;
+    for (const step of steps) {
+      switch (step) {
+        case 'body':
+          bodyRes = await stepFns.body(id);
+          break;
+        case 'date':
+          // If body step was run and failed to fetch text, skip date extraction
+          if (steps.includes('body') && bodyRes && !bodyRes.body) break;
+          await stepFns.date(id);
+          break;
+        case 'parties':
+          await stepFns.parties(id);
+          break;
+        case 'summary':
+          await stepFns.summary(id);
+          break;
+        case 'value':
+          await stepFns.value(id);
+          break;
+        default:
+          // ignore unknown step names
+          break;
+      }
     }
-    await extractParties(articleDb, configDb, openai, id);
-    await summarizeArticle(articleDb, configDb, openai, id);
-    await extractValueAndLocation(articleDb, configDb, openai, id);
   };
 };


### PR DESCRIPTION
## Summary
- refactor `pipeline.js` so the returned function accepts a list of step names
- update article routes to use `processArticle()` for each single-step endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843159f921883318b5fbf83fb1d1ab7