### PR TITLE
Fix match column and sort order

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,8 +250,16 @@ app.get('/stats', async (req, res) => {
       } catch (e) {}
     });
 
-    const row = await db.get('SELECT COUNT(*) as total, MAX(created_at) as latest, MIN(created_at) as earliest FROM articles');
-    res.json({ total: row.total, latest: row.latest, earliest: row.earliest, bySource });
+    const row = await db.get(
+      'SELECT COUNT(*) as total, MAX(created_at) as latestScrape, MIN(created_at) as earliestScrape, MIN(time) as earliestArticle FROM articles'
+    );
+    res.json({
+      total: row.total,
+      latest: row.latestScrape,
+      earliestScrape: row.earliestScrape,
+      earliestArticle: row.earliestArticle,
+      bySource
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to retrieve stats' });

--- a/public/index.html
+++ b/public/index.html
@@ -122,7 +122,7 @@
         for (const [src, count] of Object.entries(data.bySource)) {
           sourceParts += `${src}: ${count} articles `;
         }
-        div.textContent = `Total: ${data.total} | Latest: ${data.latest || 'N/A'} | Earliest: ${data.earliest || 'N/A'} | ${sourceParts}`;
+        div.textContent = `Total: ${data.total} | Latest: ${data.latest || 'N/A'} | Earliest Scrape: ${data.earliestScrape || 'N/A'} | Earliest Article: ${data.earliestArticle || 'N/A'} | ${sourceParts}`;
         if (last) last.textContent = `Last scrape: ${data.latest || 'N/A'}`;
       }
 


### PR DESCRIPTION
## Summary
- return filter matches from `/articles/enriched-list`
- order articles by the article time not scrape time
- provide earliest scrape and earliest article in stats
- update home page to display the new stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68432097e5008331ac4de565fe3bec9e