### PR TITLE
Simplify home page controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,12 +15,7 @@
     <h1 class="text-2xl font-bold mb-4">News Scraper</h1>
 
     <div class="mb-4 space-y-2">
-      <div class="flex items-center space-x-2">
-        <div class="inline-flex rounded-md shadow-sm" role="group">
-          <button id="scrapeBtn" class="px-4 py-2 bg-blue-300 hover:bg-blue-400 text-black">Scrape Articles</button>
-          <button id="runFiltersBtn" class="px-4 py-2 bg-blue-400 hover:bg-blue-500 text-black">Run Filters</button>
-        </div>
-      </div>
+      <button id="scrapeEnrichBtn" class="px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white rounded w-full">Scrape &amp; Enrich</button>
       <form id="pipelineForm" class="flex flex-wrap items-center space-x-2">
         <label class="mr-2"><input type="checkbox" name="steps" value="body" checked> Body</label>
         <label class="mr-2"><input type="checkbox" name="steps" value="date" checked> Date</label>
@@ -33,7 +28,7 @@
       </form>
       <button id="runMissingBtn" type="button" class="bg-green-500 text-white px-4 py-2 rounded">Run Missing Steps</button>
     </div>
-    <p class="text-sm text-gray-600 mb-2">Scrapes new articles, runs filters and enriches the matches.</p>
+    <p class="text-sm text-gray-600 mb-2">Scrapes new articles and enriches matching ones.</p>
 
     <div id="scrapeResults" class="mb-2 text-sm"></div>
     <div id="lastScrape" class="mb-2 text-sm"></div>
@@ -126,38 +121,25 @@
         if (last) last.textContent = `Last scrape: ${data.latest || 'N/A'}`;
       }
 
-      const scrapeBtn = document.getElementById('scrapeBtn');
-      const runFiltersBtn = document.getElementById('runFiltersBtn');
+      const scrapeEnrichBtn = document.getElementById('scrapeEnrichBtn');
       const pipelineForm = document.getElementById('pipelineForm');
       const runMissingBtn = document.getElementById('runMissingBtn');
 
-      scrapeBtn.addEventListener('click', async () => {
+      scrapeEnrichBtn.addEventListener('click', async () => {
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
         log.textContent = '';
-        div.textContent = 'Scraping started...';
+        div.textContent = 'Running full pipeline...';
 
-        const res = await fetch('/scrape');
+        const res = await fetch('/scrape-enrich');
         const data = await res.json();
         div.innerHTML = data.details
           .map(d => `${d.base_url}: scraped ${d.scraped}, added ${d.inserted}`)
           .join('<br>');
+        div.innerHTML += `<br>Total enriched: ${data.enriched}`;
         log.textContent = (data.logs || []).join('\n');
         loadArticles();
         loadStats();
-      });
-
-      runFiltersBtn.addEventListener('click', async () => {
-        const log = document.getElementById('scrapeLog');
-        const div = document.getElementById('scrapeResults');
-        log.textContent = '';
-        div.textContent = 'Running filters...';
-
-        const res = await fetch('/run-filters');
-        const data = await res.json();
-        div.textContent = `Processed ${data.processed} articles`;
-        log.textContent = (data.logs || []).join('\n');
-        loadArticles();
       });
 
       runMissingBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add a single **Scrape & Enrich** button on the homepage
- remove old `Scrape Articles` and `Run Filters` buttons
- wire the new button to the `/scrape-enrich` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6843225b23e88331b327a95b4244c938