### PR TITLE
Normalize article time when scraping

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -1,11 +1,14 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
+const normalizeDate = require('./normalizeDate');
 
 async function scrapeSource(source) {
   const response = await axios.get(source.base_url);
   const $ = cheerio.load(response.data);
 
   const articles = [];
+  const scrapedAt = new Date().toISOString();
+
   $(source.article_selector).each((i, el) => {
     const container = $(el);
     let time = '';
@@ -13,6 +16,7 @@ async function scrapeSource(source) {
       time = container.find(source.time_selector).text().trim();
       container.find(source.time_selector).remove();
     }
+    const normalizedTime = normalizeDate(time, scrapedAt) || time;
     const title = container.find(source.title_selector).text().trim();
     const description = source.description_selector
       ? container.find(source.description_selector).text().trim()
@@ -29,7 +33,7 @@ async function scrapeSource(source) {
       ? container.find(source.image_selector).attr('src') || null
       : null;
 
-    articles.push({ title, description, time, link, image });
+    articles.push({ title, description, time: normalizedTime, link, image });
   });
 
   return articles;


### PR DESCRIPTION
## Summary
- normalize article timestamp when scraping sources using `normalizeDate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68433642a4288331b0a2ea6e6d572e41