### PR TITLE
Add source duplication route and UI

### DIFF
--- a/public/manage.html
+++ b/public/manage.html
@@ -118,6 +118,7 @@
            `<td contenteditable="true" class="border px-2 py-1">${s.date_selector || ''}</td>` +
            `<td class="border px-2 py-1">` +
             `<button data-id="${s.id}" class="saveSource bg-blue-500 text-white px-2 py-1 rounded mr-2">Save</button>` +
+            `<button data-id="${s.id}" class="duplicateSource bg-purple-500 text-white px-2 py-1 rounded mr-2">Duplicate</button>` +
             `<button data-id="${s.id}" class="deleteSource bg-red-500 text-white px-2 py-1 rounded">Delete</button>` +
             `</td>`;
           tbody.appendChild(tr);
@@ -153,6 +154,14 @@
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(payload)
             });
+            loadSources();
+          });
+        });
+
+        document.querySelectorAll('.duplicateSource').forEach(btn => {
+          btn.addEventListener('click', async e => {
+            const id = e.target.getAttribute('data-id');
+            await fetch(`/sources/${id}/duplicate`, { method: 'POST' });
             loadSources();
           });
         });

--- a/routes/sources.js
+++ b/routes/sources.js
@@ -67,6 +67,36 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
+// Duplicate a scraping source
+router.post('/:id/duplicate', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const source = await configDb.get('SELECT * FROM sources WHERE id = ?', [id]);
+    if (!source) return res.status(404).json({ error: 'Source not found' });
+    const params = [
+      source.base_url,
+      source.article_selector,
+      source.title_selector,
+      source.description_selector,
+      source.time_selector,
+      source.link_selector,
+      source.image_selector,
+      source.body_selector,
+      source.location_selector,
+      source.date_selector,
+    ];
+    const result = await configDb.run(
+      `INSERT INTO sources (base_url, article_selector, title_selector, description_selector, time_selector, link_selector, image_selector, body_selector, location_selector, date_selector)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      params
+    );
+    res.json({ id: result.lastID });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to duplicate source' });
+  }
+});
+
 // Update a scraping source
 router.put('/:id', async (req, res) => {
   const { id } = req.params;


### PR DESCRIPTION
## Summary
- add `/sources/:id/duplicate` API endpoint to clone a scraping source
- add Duplicate button on manage page with handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843374606e4833190f51042f21f4298