### PR TITLE
Allow streaming logs for pipeline and add filters step

### DIFF
--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -3,9 +3,11 @@ const extractDateLocation = require('./extractDateLocation');
 const extractParties = require('./extractParties');
 const summarizeArticle = require('./summarizeArticle');
 const extractValueAndLocation = require('./extractValueAndLocation');
+const { runFilters } = require('../filters');
 
 module.exports = (articleDb, configDb, openai) => {
   const stepFns = {
+    filters: (id, logs) => runFilters(articleDb, configDb, [id], logs),
     body: id => fetchAndStoreBody(articleDb, configDb, openai, id),
     date: id => extractDateLocation(articleDb, configDb, id),
     parties: id => extractParties(articleDb, configDb, openai, id),
@@ -13,12 +15,15 @@ module.exports = (articleDb, configDb, openai) => {
     value: id => extractValueAndLocation(articleDb, configDb, openai, id)
   };
 
-  const allSteps = Object.keys(stepFns);
+  const defaultSteps = ['body', 'date', 'parties', 'summary', 'value'];
 
-  return async function processArticle(id, steps = allSteps) {
+  return async function processArticle(id, steps = defaultSteps, logs = []) {
     let bodyRes = null;
     for (const step of steps) {
       switch (step) {
+        case 'filters':
+          await stepFns.filters(id, logs);
+          break;
         case 'body':
           bodyRes = await stepFns.body(id);
           break;

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
     <div class="mb-4 space-y-2">
       <button id="scrapeEnrichBtn" class="px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white rounded w-full">Scrape &amp; Enrich</button>
       <form id="pipelineForm" class="flex flex-wrap items-center space-x-2">
+        <label class="mr-2"><input type="checkbox" name="steps" value="filters" checked> Filters</label>
         <label class="mr-2"><input type="checkbox" name="steps" value="body" checked> Body</label>
         <label class="mr-2"><input type="checkbox" name="steps" value="date" checked> Date</label>
         <label class="mr-2"><input type="checkbox" name="steps" value="parties" checked> Parties</label>
@@ -154,7 +155,7 @@
         });
       });
 
-      runMissingBtn.addEventListener('click', async () => {
+      runMissingBtn.addEventListener('click', () => {
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
         log.textContent = '';
@@ -169,19 +170,25 @@
         if (since) params.set('since', since);
         params.set('incomplete', '1');
 
-        const res = await fetch(`/pipeline/run?${params.toString()}`);
-        const data = await res.json();
-        if (!res.ok || data.error) {
-          div.textContent = 'Error running pipeline';
-        } else {
-          div.textContent = `Processed ${data.processed} articles`;
-        }
-        log.textContent = (data.logs || []).join('\n');
-        loadArticles();
-        loadStats();
+        const es = new EventSource(`/pipeline/run-stream?${params.toString()}`);
+        es.onmessage = e => {
+          log.textContent += e.data + '\n';
+          log.scrollTop = log.scrollHeight;
+        };
+        es.addEventListener('done', e => {
+          es.close();
+          try {
+            const data = JSON.parse(e.data);
+            div.textContent = `Processed ${data.processed} articles`;
+          } catch (_) {
+            div.textContent = 'Pipeline completed';
+          }
+          loadArticles();
+          loadStats();
+        });
       });
 
-      pipelineForm.addEventListener('submit', async e => {
+      pipelineForm.addEventListener('submit', e => {
         e.preventDefault();
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
@@ -198,16 +205,22 @@
         if (since) params.set('since', since);
         if (incomplete) params.set('incomplete', '1');
 
-        const res = await fetch(`/pipeline/run?${params.toString()}`);
-        const data = await res.json();
-        if (!res.ok || data.error) {
-          div.textContent = 'Error running pipeline';
-        } else {
-          div.textContent = `Processed ${data.processed} articles`;
-        }
-        log.textContent = (data.logs || []).join('\n');
-        loadArticles();
-        loadStats();
+        const es = new EventSource(`/pipeline/run-stream?${params.toString()}`);
+        es.onmessage = e => {
+          log.textContent += e.data + '\n';
+          log.scrollTop = log.scrollHeight;
+        };
+        es.addEventListener('done', e => {
+          es.close();
+          try {
+            const data = JSON.parse(e.data);
+            div.textContent = `Processed ${data.processed} articles`;
+          } catch (_) {
+            div.textContent = 'Pipeline completed';
+          }
+          loadArticles();
+          loadStats();
+        });
       });
 
       loadArticles();

--- a/routes/pipeline.js
+++ b/routes/pipeline.js
@@ -8,7 +8,7 @@ const { getCompleted } = require('../lib/enrichment/steps');
 const router = express.Router();
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const processArticle = createPipeline(db, configDb, openai);
-const VALID_STEPS = ['body', 'date', 'parties', 'summary', 'value'];
+const VALID_STEPS = ['filters', 'body', 'date', 'parties', 'summary', 'value'];
 
 router.get('/run', async (req, res) => {
   try {
@@ -60,6 +60,72 @@ router.get('/run', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to run pipeline' });
+  }
+});
+
+router.get('/run-stream', async (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  const send = msg => res.write(`data: ${msg}\n\n`);
+
+  try {
+    let steps = (req.query.steps || '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+    steps = steps.filter(s => VALID_STEPS.includes(s));
+    if (!steps.length) steps = VALID_STEPS;
+
+    let ids = [];
+    if (req.query.ids) {
+      ids = req.query.ids
+        .split(',')
+        .map(id => parseInt(id, 10))
+        .filter(id => !isNaN(id));
+    } else if (req.query.since) {
+      const rows = await db.all(
+        'SELECT id FROM articles WHERE created_at >= ?',
+        [req.query.since]
+      );
+      ids = rows.map(r => r.id);
+    } else {
+      const rows = await db.all('SELECT id FROM articles');
+      ids = rows.map(r => r.id);
+    }
+
+    const incompleteOnly =
+      req.query.incomplete === '1' || req.query.incomplete === 'true';
+
+    let processed = 0;
+    const logs = [];
+
+    for (const id of ids) {
+      if (incompleteOnly) {
+        const completed = await getCompleted(db, id);
+        const missing = steps.filter(s => !completed.includes(s));
+        if (!missing.length) continue;
+      }
+      try {
+        await processArticle(id, steps, logs);
+        logs.forEach(send);
+        logs.length = 0;
+        processed++;
+        send(`Processed ${processed}/${ids.length}`);
+      } catch (e) {
+        send(`Failed to process article ${id}: ${e.message}`);
+      }
+    }
+
+    res.write(`event: done\ndata: ${JSON.stringify({ processed })}\n\n`);
+    res.end();
+  } catch (err) {
+    console.error(err);
+    send(`Error: ${err.message}`);
+    res.write(`event: done\ndata: ${JSON.stringify({ error: 'Failed to run pipeline' })}\n\n`);
+    res.end();
   }
 });
 


### PR DESCRIPTION
## Summary
- add a `filters` step to the enrichment pipeline
- expose `/pipeline/run-stream` endpoint for SSE logging
- stream logs for pipeline actions in the UI
- include a checkbox for the Filters step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684343ebf0208331ac966fc5dab5b3bd