### PR TITLE
Add basic Prisma integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Install dependencies using npm before running the server:
 npm install
 ```
 
+After installing dependencies run the Prisma generator to create the client:
+
+```bash
+npm run prisma:generate
+```
+
+To apply schema changes use the migration command:
+
+```bash
+npm run prisma:migrate
+```
+
 ## Running the server
 
 Start the server with:
@@ -36,7 +48,7 @@ The server listens on the port defined by `PORT` or defaults to `3000`.
 ## Project structure
 
 - `index.js` – main entry point and Express setup
-- `db.js` – SQLite database connection
+ - `db.js` – Prisma wrapper around the SQLite database
 - `routes/` – route handlers for articles, sources and filters
 - `lib/` – utility modules (scraping, filtering, enrichment)
 - `public/` – static client pages

--- a/configDb.js
+++ b/configDb.js
@@ -1,39 +1,22 @@
-const sqlite3 = require('sqlite3').verbose();
-const path = require('path');
+const prisma = require('./prismaClient');
 
-const connection = new sqlite3.Database(
-  path.join(__dirname, 'config.db')
-);
-
-function run(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    connection.run(sql, params, function (err) {
-      if (err) return reject(err);
-      resolve({ lastID: this.lastID, changes: this.changes });
-    });
-  });
+async function run(sql, params = []) {
+  const changes = await prisma.$executeRawUnsafe(sql, ...params);
+  return { lastID: 0, changes: typeof changes === 'number' ? changes : 0 };
 }
 
-function get(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    connection.get(sql, params, (err, row) => {
-      if (err) return reject(err);
-      resolve(row);
-    });
-  });
+async function get(sql, params = []) {
+  const rows = await prisma.$queryRawUnsafe(sql, ...params);
+  return rows[0] || null;
 }
 
-function all(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    connection.all(sql, params, (err, rows) => {
-      if (err) return reject(err);
-      resolve(rows);
-    });
-  });
+async function all(sql, params = []) {
+  const rows = await prisma.$queryRawUnsafe(sql, ...params);
+  return rows;
 }
 
 function serialize(fn) {
-  connection.serialize(fn);
+  return fn();
 }
 
-module.exports = { run, get, all, serialize, raw: connection };
+module.exports = { run, get, all, serialize, raw: prisma };

--- a/db.js
+++ b/db.js
@@ -1,39 +1,22 @@
-const sqlite3 = require('sqlite3').verbose();
-const path = require('path');
+const prisma = require('./prismaClient');
 
-const connection = new sqlite3.Database(
-  path.join(__dirname, 'raw_articles.db')
-);
-
-function run(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    connection.run(sql, params, function (err) {
-      if (err) return reject(err);
-      resolve({ lastID: this.lastID, changes: this.changes });
-    });
-  });
+async function run(sql, params = []) {
+  const changes = await prisma.$executeRawUnsafe(sql, ...params);
+  return { lastID: 0, changes: typeof changes === 'number' ? changes : 0 };
 }
 
-function get(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    connection.get(sql, params, (err, row) => {
-      if (err) return reject(err);
-      resolve(row);
-    });
-  });
+async function get(sql, params = []) {
+  const rows = await prisma.$queryRawUnsafe(sql, ...params);
+  return rows[0] || null;
 }
 
-function all(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    connection.all(sql, params, (err, rows) => {
-      if (err) return reject(err);
-      resolve(rows);
-    });
-  });
+async function all(sql, params = []) {
+  const rows = await prisma.$queryRawUnsafe(sql, ...params);
+  return rows;
 }
 
 function serialize(fn) {
-  connection.serialize(fn);
+  return fn();
 }
 
-module.exports = { run, get, all, serialize, raw: connection };
+module.exports = { run, get, all, serialize, raw: prisma };

--- a/prismaClient.js
+++ b/prismaClient.js
@@ -1,0 +1,9 @@
+const { PrismaClient } = require('@prisma/client');
+
+const globalForPrisma = global;
+
+const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+module.exports = prisma;


### PR DESCRIPTION
## Summary
- introduce `prismaClient.js` for a singleton Prisma client
- rewrite `db.js` and `configDb.js` to use Prisma
- document Prisma commands in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68445d5dcec88331b462d72f570deb82