### PR TITLE
Fix Postgres compatibility

### DIFF
--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -2,10 +2,10 @@ async function getPrompt(db, name, defaultTemplate) {
   const row = await db.get('SELECT template FROM prompts WHERE name = ?', [name]);
   if (row && row.template) return row.template;
   if (defaultTemplate !== undefined) {
-    await db.run(
-      'INSERT OR IGNORE INTO prompts (name, template) VALUES (?, ?)',
-      [name, defaultTemplate]
-    );
+    const sql = db.raw.getDialect && db.raw.getDialect() === 'postgres'
+      ? 'INSERT INTO prompts (name, template) VALUES (?, ?) ON CONFLICT DO NOTHING'
+      : 'INSERT OR IGNORE INTO prompts (name, template) VALUES (?, ?)';
+    await db.run(sql, [name, defaultTemplate]);
     return defaultTemplate;
   }
   return null;


### PR DESCRIPTION
## Summary
- add detection for Postgres dialect and generate appropriate SQL
- handle missing columns without PRAGMA
- use dialect specific GROUP_CONCAT/STRING_AGG
- support ON CONFLICT equivalent for Postgres when inserting

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_b_68449cfe99948331a279ba3aa30f78a6