### PR TITLE
Add production DB mode and postgres datetime fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Articles can also be summarized with sector and industry labels using GPT.
 ## Prerequisites
 
 - Node.js 18 or newer (the repo uses Node.js 22 via the `.replit` config)
-- The server uses SQLite by default but can connect to Postgres via `DATABASE_URL`
+- The server uses SQLite when `NODE_ENV` is not `production`. In production a
+  Postgres connection is required via `DATABASE_URL`.
 - Scraping sources, filters and prompts are stored in `config.db`
 - To run enrichment routes you must set the `OPENAI_API_KEY` environment variable
 
@@ -32,8 +33,9 @@ The server listens on the port defined by `PORT` or defaults to `3000`.
 
 - `OPENAI_API_KEY` – required for enrichment endpoints
 - `PORT` – optional port number (defaults to `3000`)
-- `DATABASE_URL` – optional Postgres connection string
-- `CONFIG_DB_URL` – optional Postgres connection for config data
+- `NODE_ENV` – set to `production` to use Postgres
+- `DATABASE_URL` – Postgres connection string (required in production)
+- `CONFIG_DB_URL` – Postgres connection for config data (required in production)
 
 ## Project structure
 

--- a/configDb.js
+++ b/configDb.js
@@ -2,7 +2,11 @@ const { Sequelize, QueryTypes } = require('sequelize');
 const path = require('path');
 
 let sequelize;
-if (process.env.CONFIG_DB_URL) {
+const isProd = process.env.NODE_ENV === 'production';
+if (isProd) {
+  if (!process.env.CONFIG_DB_URL) {
+    throw new Error('CONFIG_DB_URL must be set in production');
+  }
   sequelize = new Sequelize(process.env.CONFIG_DB_URL, { logging: false });
 } else {
   sequelize = new Sequelize({

--- a/db.js
+++ b/db.js
@@ -2,7 +2,11 @@ const { Sequelize, QueryTypes } = require('sequelize');
 const path = require('path');
 
 let sequelize;
-if (process.env.DATABASE_URL) {
+const isProd = process.env.NODE_ENV === 'production';
+if (isProd) {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL must be set in production');
+  }
   sequelize = new Sequelize(process.env.DATABASE_URL, { logging: false });
 } else {
   sequelize = new Sequelize({

--- a/index.js
+++ b/index.js
@@ -14,13 +14,15 @@ const PORT = process.env.PORT || 3000;
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const processArticle = createPipeline(db, configDb, openai);
 
-const isPg = db.raw.getDialect() === 'postgres';
-const configIsPg = configDb.raw.getDialect() === 'postgres';
+const isPg = db.raw?.getDialect() === 'postgres';
+const configIsPg = configDb.raw?.getDialect() === 'postgres';
 const idColumn = isPg ? 'SERIAL PRIMARY KEY' : 'INTEGER PRIMARY KEY';
 const configIdColumn = configIsPg ? 'SERIAL PRIMARY KEY' : 'INTEGER PRIMARY KEY';
+const dateTime = isPg ? 'TIMESTAMP' : 'DATETIME';
+const configDateTime = configIsPg ? 'TIMESTAMP' : 'DATETIME';
 
 async function hasColumn(database, table, column) {
-  if (database.raw.getDialect() === 'postgres') {
+  if (database.raw?.getDialect() === 'postgres') {
     const row = await database.get(
       `SELECT column_name FROM information_schema.columns WHERE table_name = ? AND column_name = ?`,
       [table, column]
@@ -46,7 +48,7 @@ async function initDb() {
     time TEXT,
     link TEXT UNIQUE,
     image TEXT,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    created_at ${dateTime} DEFAULT CURRENT_TIMESTAMP
   )`);
 
   await configDb.run(`CREATE TABLE IF NOT EXISTS filters (
@@ -55,14 +57,14 @@ async function initDb() {
     type TEXT NOT NULL, -- 'keyword' or 'embedding'
     value TEXT,
     active INTEGER DEFAULT 1,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    created_at ${configDateTime} DEFAULT CURRENT_TIMESTAMP
   )`);
 
   await db.run(`CREATE TABLE IF NOT EXISTS article_filter_matches (
     id ${idColumn},
     article_id INTEGER,
     filter_id INTEGER,
-    matched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    matched_at ${dateTime} DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(article_id) REFERENCES articles(id)
   )`);
 
@@ -88,7 +90,7 @@ async function initDb() {
   await db.run(`CREATE TABLE IF NOT EXISTS article_enrichment_steps (
     article_id INTEGER,
     step_name TEXT,
-    completed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    completed_at ${dateTime} DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY(article_id, step_name),
     FOREIGN KEY(article_id) REFERENCES articles(id)
   )`);

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -2,7 +2,7 @@ async function getPrompt(db, name, defaultTemplate) {
   const row = await db.get('SELECT template FROM prompts WHERE name = ?', [name]);
   if (row && row.template) return row.template;
   if (defaultTemplate !== undefined) {
-    const sql = db.raw.getDialect && db.raw.getDialect() === 'postgres'
+    const sql = db.raw && db.raw.getDialect && db.raw.getDialect() === 'postgres'
       ? 'INSERT INTO prompts (name, template) VALUES (?, ?) ON CONFLICT DO NOTHING'
       : 'INSERT OR IGNORE INTO prompts (name, template) VALUES (?, ?)';
     await db.run(sql, [name, defaultTemplate]);

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -26,7 +26,7 @@ const processArticle = createPipeline(db, configDb, openai);
 
 // Get all articles
 router.get('/', async (req, res) => {
-  const agg = db.raw.getDialect() === 'postgres'
+  const agg = db.raw && db.raw.getDialect() === 'postgres'
     ? "STRING_AGG(m.filter_id::text, ',')"
     : 'GROUP_CONCAT(m.filter_id)';
   const query = `
@@ -162,7 +162,7 @@ router.get('/enriched-list', async (req, res) => {
   const level = req.query.level || 'all';
   const includeAll = req.query.all === '1' || req.query.all === 'true';
 
-  const agg = db.raw.getDialect() === 'postgres'
+  const agg = db.raw && db.raw.getDialect() === 'postgres'
     ? "STRING_AGG(m.filter_id::text, ',')"
     : 'GROUP_CONCAT(m.filter_id)';
 


### PR DESCRIPTION
## Summary
- use `NODE_ENV` to determine postgres vs sqlite
- throw if missing postgres URL in production
- fix DATETIME creation on postgres
- make DB dialect checks safe for tests
- document environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a0a8f7888331b54a4b99e68a3cb1