### PR TITLE
Improve enrichment error handling

### DIFF
--- a/lib/enrichment/fetchAndStoreBody.js
+++ b/lib/enrichment/fetchAndStoreBody.js
@@ -6,6 +6,7 @@ const { markCompleted, getCompleted } = require('./steps');
 async function fetchAndStoreBody(articleDb, configDb, openai, id) {
   const article = await articleDb.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
+  if (!article.link) throw new Error('Article link missing');
 
   const sources = await configDb.all('SELECT * FROM sources');
 
@@ -22,7 +23,13 @@ async function fetchAndStoreBody(articleDb, configDb, openai, id) {
     if (src) bodySelector = src.body_selector || null;
   } catch (e) {}
 
-  const response = await axios.get(article.link);
+  let response;
+  try {
+    response = await axios.get(article.link);
+  } catch (err) {
+    await appendLog(articleDb, id, `Failed to fetch article: ${err.message}`);
+    throw new Error('Failed to fetch article');
+  }
   const $ = cheerio.load(response.data);
 
   const fallbackSelectors = [
@@ -58,6 +65,10 @@ async function fetchAndStoreBody(articleDb, configDb, openai, id) {
     .join('\n');
   if (!text) {
     text = container.text().trim();
+  }
+  if (!text) {
+    await appendLog(articleDb, id, 'No body text found');
+    throw new Error('Article text not found');
   }
 
   let embeddingJson = null;

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -236,7 +236,8 @@ router.post('/:id/enrich', async (req, res) => {
     res.json({ success: true, body: row.body, date: row.date, location: row.location });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to enrich article' });
+    const msg = err && err.message ? err.message : 'Failed to enrich article';
+    res.status(500).json({ error: msg });
   }
 });
 


### PR DESCRIPTION
## Summary
- catch invalid/missing article links and HTTP errors when fetching body text
- surface server error message when enriching an article

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844b84808948331a1ef546f3929fb83