### PR TITLE
Fix scraper duplicates

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -1,10 +1,18 @@
-const axios = require('axios');
-const cheerio = require('cheerio');
+let defaultHttp;
+let cheerioLib;
 const normalizeDate = require('./normalizeDate');
 
-async function scrapeSource(source) {
-  const response = await axios.get(source.base_url);
-  const $ = cheerio.load(response.data);
+async function scrapeSource(source, http, parser) {
+  if (!http) {
+    if (!defaultHttp) defaultHttp = require('axios');
+    http = defaultHttp;
+  }
+  if (!parser) {
+    if (!cheerioLib) cheerioLib = require('cheerio');
+    parser = cheerioLib;
+  }
+  const response = await http.get(source.base_url);
+  const $ = parser.load(response.data);
 
   const articles = [];
   const scrapedAt = new Date().toISOString();
@@ -35,8 +43,18 @@ async function scrapeSource(source) {
 
     articles.push({ title, description, time: normalizedTime, link, image });
   });
-
-  return articles;
+  return dedupeArticles(articles);
 }
 
-module.exports = { scrapeSource };
+function dedupeArticles(articles) {
+  const seen = new Set();
+  const deduped = [];
+  for (const article of articles) {
+    const key = article.link || `${article.title}-${article.time}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(article);
+  }
+  return deduped;
+}
+module.exports = { scrapeSource, dedupeArticles };

--- a/test/scraper.test.js
+++ b/test/scraper.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { dedupeArticles } = require('../lib/scraper');
+
+const html = `
+  <div class="card">
+    <h3>Title 1 <small>Jan 1</small></h3>
+    <p>Desc</p>
+    <a href="/a1">Read</a>
+  </div>
+  <div class="card">
+    <h3>Title 1 <small>Jan 1</small></h3>
+    <p>Desc</p>
+    <a href="/a1">Read</a>
+  </div>
+  <div class="card">
+    <h3>Title 2 <small>Jan 2</small></h3>
+    <p>Desc2</p>
+    <a href="/a2">Read</a>
+  </div>
+`;
+
+const source = {
+  base_url: 'http://example.com',
+  article_selector: 'div.card',
+  title_selector: 'h3',
+  description_selector: 'p',
+  time_selector: 'h3 small',
+  link_selector: 'a',
+  image_selector: null,
+};
+
+test('dedupeArticles removes duplicate articles by link', () => {
+  const articles = [
+    { title: 'Title 1', link: 'http://example.com/a1', description: '', time: '1', image: null },
+    { title: 'Title 1', link: 'http://example.com/a1', description: '', time: '1', image: null },
+    { title: 'Title 2', link: 'http://example.com/a2', description: '', time: '2', image: null }
+  ];
+  const deduped = dedupeArticles(articles);
+  assert.equal(deduped.length, 2);
+  assert.deepEqual(
+    deduped.map(a => a.link).sort(),
+    ['http://example.com/a1', 'http://example.com/a2']
+  );
+});


### PR DESCRIPTION
## Summary
- remove duplicate articles when scraping by link
- expose `dedupeArticles` utility
- add regression test for deduplication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f4ba0f28833188793eea2536ed5f