### PR TITLE
Fix filter pipeline for Postgres

### DIFF
--- a/lib/insertArticles.js
+++ b/lib/insertArticles.js
@@ -1,0 +1,25 @@
+async function insertArticles(db, articles, isPg) {
+  const sql = isPg
+    ? 'INSERT INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING'
+    : 'INSERT OR IGNORE INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, ?)';
+
+  const results = await Promise.all(
+    articles.map(async a => {
+      const result = await db.run(sql, [a.title, a.description, a.time, a.link, a.image]);
+      if (isPg && result.changes > 0) {
+        const row = await db.get('SELECT id FROM articles WHERE link = ?', [a.link]);
+        result.lastID = row && row.id;
+      }
+      return result;
+    })
+  );
+
+  const inserted = results.reduce((acc, cur) => acc + cur.changes, 0);
+  const insertedIds = results
+    .filter(r => r.changes > 0 && typeof r.lastID !== 'undefined')
+    .map(r => r.lastID);
+
+  return { inserted, insertedIds };
+}
+
+module.exports = insertArticles;

--- a/test/insertArticles.test.js
+++ b/test/insertArticles.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const insertArticles = require('../lib/insertArticles');
+
+function createDb(options) {
+  const inserted = [];
+  return {
+    run: async (sql, params) => {
+      const id = options.nextId++;
+      if (options.isPg) {
+        // Postgres style: no lastID returned
+        inserted.push({ id, params });
+        return { changes: 1 };
+      }
+      inserted.push({ id, params });
+      return { changes: 1, lastID: id };
+    },
+    get: async (sql, params) => {
+      // return id based on params
+      const match = inserted.find(r => r.params[3] === params[0]);
+      return match ? { id: match.id } : undefined;
+    }
+  };
+}
+
+test('returns inserted IDs for sqlite', async () => {
+  const db = createDb({ nextId: 1, isPg: false });
+  const articles = [
+    { title: 't', description: '', time: '1', link: 'a', image: null }
+  ];
+  const { inserted, insertedIds } = await insertArticles(db, articles, false);
+  assert.equal(inserted, 1);
+  assert.deepEqual(insertedIds, [1]);
+});
+
+test('fetches IDs when lastID is missing (postgres)', async () => {
+  const db = createDb({ nextId: 10, isPg: true });
+  const articles = [
+    { title: 't2', description: '', time: '2', link: 'b', image: null }
+  ];
+  const { inserted, insertedIds } = await insertArticles(db, articles, true);
+  assert.equal(inserted, 1);
+  assert.deepEqual(insertedIds, [10]);
+});


### PR DESCRIPTION
## Summary
- handle Postgres insert logic by looking up article IDs when lastID is missing
- log inserted article IDs
- reuse insertion logic via new helper `insertArticles`
- add tests for `insertArticles`

## Testing
- `npm test`
- `npm start` *(fails: MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_b_68460bb46880833191449d785d1eb735