### PR TITLE
Add debug logging to track PG inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The server listens on the port defined by `PORT` or defaults to `3000`.
 - `PORT` – optional port number (defaults to `3000`)
 - `NODE_ENV` – set to `production` to use Postgres
 - `DATABASE_URL` – Postgres connection string (required in production)
+- `DEBUG` – set to `1` to log detailed DB operations
 
 ## Project structure
 

--- a/lib/insertArticles.js
+++ b/lib/insertArticles.js
@@ -1,3 +1,5 @@
+const logger = require('../logger');
+
 async function insertArticles(db, articles, isPg) {
   const sql = isPg
     ? 'INSERT INTO articles (title, description, time, link, image) VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING'
@@ -6,9 +8,20 @@ async function insertArticles(db, articles, isPg) {
   const results = await Promise.all(
     articles.map(async a => {
       const result = await db.run(sql, [a.title, a.description, a.time, a.link, a.image]);
-      if (isPg && result.changes > 0) {
+      if (process.env.DEBUG) {
+        logger.debug(`Insert result for ${a.link || a.title}: ${JSON.stringify(result)}`);
+      }
+      if (isPg) {
         const row = await db.get('SELECT id FROM articles WHERE link = ?', [a.link]);
-        result.lastID = row && row.id;
+        if (row) {
+          result.lastID = row.id;
+          if (!result.changes) {
+            result.changes = 1;
+            if (process.env.DEBUG) {
+              logger.debug(`Row found for ${a.link || a.title} despite 0 changes`);
+            }
+          }
+        }
       }
       return result;
     })

--- a/logger.js
+++ b/logger.js
@@ -7,6 +7,7 @@ if (!fs.existsSync(logDir)) {
 }
 
 const logPath = path.join(logDir, 'app.log');
+const debugEnabled = process.env.DEBUG === '1' || process.env.DEBUG === 'true';
 
 function write(level, message) {
   const line = `${new Date().toISOString()} ${level}: ${message}\n`;
@@ -17,4 +18,8 @@ module.exports = {
   info: msg => write('INFO', msg),
   error: msg =>
     write('ERROR', msg instanceof Error ? msg.stack || msg.message : msg)
+  ,
+  debug: msg => {
+    if (debugEnabled) write('DEBUG', msg);
+  }
 };

--- a/test/insertArticles.test.js
+++ b/test/insertArticles.test.js
@@ -10,6 +10,7 @@ function createDb(options) {
       if (options.isPg) {
         // Postgres style: no lastID returned
         inserted.push({ id, params });
+        if (options.missingRowCount) return {};
         return { changes: 1 };
       }
       inserted.push({ id, params });
@@ -41,4 +42,14 @@ test('fetches IDs when lastID is missing (postgres)', async () => {
   const { inserted, insertedIds } = await insertArticles(db, articles, true);
   assert.equal(inserted, 1);
   assert.deepEqual(insertedIds, [10]);
+});
+
+test('handles missing rowCount by verifying row existence', async () => {
+  const db = createDb({ nextId: 20, isPg: true, missingRowCount: true });
+  const articles = [
+    { title: 't3', description: '', time: '3', link: 'c', image: null }
+  ];
+  const { inserted, insertedIds } = await insertArticles(db, articles, true);
+  assert.equal(inserted, 1);
+  assert.deepEqual(insertedIds, [20]);
 });


### PR DESCRIPTION
## Summary
- add `DEBUG` environment variable docs
- add debug logging capability to logger
- log insert results and check row existence for PG
- test insert with missing rowCount handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68460fb05e74833197529675e61b7789