### PR TITLE
Allow prompt field editing in config UI

### DIFF
--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -1,7 +1,9 @@
 const {
-  parseOpenAIResponse,
   getFirstSentence,
-  DEFAULT_TEMPLATE
+  DEFAULT_TEMPLATE,
+  DEFAULT_FIELDS,
+  parseFields,
+  toCamel
 } = require('../extractParties');
 const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
@@ -18,7 +20,12 @@ async function extractParties(articleDb, configDb, openai, id) {
 
   const firstSentence = getFirstSentence(row.body);
   const titleAndSentence = `${row.title || ''} ${firstSentence}`.trim();
-  const template = await getPrompt(configDb, 'extractParties', DEFAULT_TEMPLATE);
+  const { template, fields = DEFAULT_FIELDS } = await getPrompt(
+    configDb,
+    'extractParties',
+    DEFAULT_TEMPLATE,
+    DEFAULT_FIELDS
+  );
   const prompt = template.replace('{text}', titleAndSentence);
 
   const resp = await openai.chat.completions.create({
@@ -28,16 +35,38 @@ async function extractParties(articleDb, configDb, openai, id) {
   });
 
   const output = resp.choices[0].message.content.trim();
-  const { acquiror, seller, target, transactionType } = parseOpenAIResponse(output);
+  const parsed = parseFields(output, fields);
+  const dbVals = {};
+  for (const f of fields) {
+    const camel = toCamel(f);
+    let val = parsed[camel];
+    if (['acquiror', 'seller', 'target'].includes(f)) {
+      val = val || 'N/A';
+    } else if (f === 'transaction_type') {
+      val = val || 'Other';
+    } else if (val === undefined) {
+      val = '';
+    }
+    dbVals[f] = val;
+  }
 
+  const columns = Object.keys(dbVals).join(', ');
+  const placeholders = Object.keys(dbVals).map(() => '?').join(', ');
+  const updates = Object.keys(dbVals)
+    .map(c => `${c} = excluded.${c}`)
+    .join(', ');
   await articleDb.run(
-    `INSERT INTO article_enrichments (article_id, acquiror, seller, target, transaction_type)
-       VALUES (?, ?, ?, ?, ?)
-       ON CONFLICT(article_id) DO UPDATE SET acquiror = excluded.acquiror, seller = excluded.seller, target = excluded.target, transaction_type = excluded.transaction_type`,
-    [id, acquiror, seller, target, transactionType]
+    `INSERT INTO article_enrichments (article_id, ${columns})
+       VALUES (?, ${placeholders})
+       ON CONFLICT(article_id) DO UPDATE SET ${updates}`,
+    [id, ...Object.values(dbVals)]
   );
 
-  await appendLog(articleDb, id, `Extracted parties a:${acquiror} s:${seller} t:${target} type:${transactionType}`);
+  await appendLog(
+    articleDb,
+    id,
+    `Extracted parties ${fields.map(f => `${f}:${dbVals[f]}`).join(' ')}`
+  );
 
   await markCompleted(articleDb, id, 'parties');
   const completed = await getCompleted(articleDb, id);
@@ -47,10 +76,9 @@ async function extractParties(articleDb, configDb, openai, id) {
     firstSentence,
     prompt,
     output,
-    acquiror,
-    seller,
-    target,
-    transactionType,
+    ...Object.fromEntries(
+      Object.entries(dbVals).map(([k, v]) => [toCamel(k), v])
+    ),
     completed: completed.join(',')
   };
 }

--- a/lib/enrichment/extractValueAndLocation.js
+++ b/lib/enrichment/extractValueAndLocation.js
@@ -13,10 +13,11 @@ async function extractValueAndLocation(articleDb, configDb, openai, id) {
     throw new Error('Article text not found');
   }
 
-  const template = await getPrompt(
+  const { template, fields = ['deal_value', 'location'] } = await getPrompt(
     configDb,
     'extractValueLocation',
-    DEFAULT_TEMPLATE
+    DEFAULT_TEMPLATE,
+    ['deal_value', 'location']
   );
   const prompt = template
     .replace('{text}', row.body)

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -22,10 +22,11 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
     throw new Error('Article text not found');
   }
 
-  const template = await getPrompt(
+  const { template, fields = ['summary', 'sector', 'industry'] } = await getPrompt(
     configDb,
     'summarizeArticle',
-    DEFAULT_TEMPLATE
+    DEFAULT_TEMPLATE,
+    ['summary', 'sector', 'industry']
   );
   const prompt = template.replace('{text}', row.body);
 

--- a/lib/extractParties.js
+++ b/lib/extractParties.js
@@ -1,24 +1,35 @@
 const { parseTransactionType } = require('./classifyTransaction');
 
-function parseOpenAIResponse(text) {
-  let acquiror = 'N/A';
-  let seller = 'N/A';
-  let target = 'N/A';
-  let transactionType = 'Other';
+function toCamel(str) {
+  return str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+function parseFields(text, fields) {
+  let obj = {};
   try {
-    const parsed = JSON.parse(text.trim());
-    if (parsed.acquiror) acquiror = parsed.acquiror;
-    if (parsed.seller) seller = parsed.seller;
-    if (parsed.target) target = parsed.target;
-    if (parsed.transaction_type || parsed.transactionType) {
-      transactionType = parseTransactionType(
-        parsed.transaction_type || parsed.transactionType
-      );
-    }
+    obj = JSON.parse(text.trim());
   } catch (e) {
-    // ignore parsing errors
+    obj = {};
   }
-  return { acquiror, seller, target, transactionType };
+  const res = {};
+  for (const f of fields) {
+    const camel = toCamel(f);
+    let val = obj[f];
+    if (val === undefined) val = obj[camel];
+    if (f === 'transaction_type' && val) val = parseTransactionType(val);
+    res[camel] = val;
+  }
+  return res;
+}
+
+function parseOpenAIResponse(text) {
+  const parsed = parseFields(text, DEFAULT_FIELDS);
+  return {
+    acquiror: parsed.acquiror || 'N/A',
+    seller: parsed.seller || 'N/A',
+    target: parsed.target || 'N/A',
+    transactionType: parsed.transactionType || 'Other'
+  };
 }
 
 function getFirstSentence(text) {
@@ -75,7 +86,15 @@ function getFirstSentence(text) {
 const DEFAULT_TEMPLATE =
   'Extract the acquiror, seller, target and the transaction type ("M&A", "Financing" or "Other"). Anything relating to one party buying, acquiring another is considered "M&A". The target and seller are often the same in an M&A transaction, but the target may also be select assets or a division of the seller. In a financing, the company issuing the financing is the seller. If none are mentioned, respond with JSON {"acquiror":"N/A","seller":"N/A","target":"N/A","transactionType":"Other"}.  Text: "{text}"';
 
-async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) {
+const DEFAULT_FIELDS = ['acquiror', 'seller', 'target', 'transaction_type'];
+
+async function extractParties(
+  openai,
+  title,
+  body,
+  template = DEFAULT_TEMPLATE,
+  fields = DEFAULT_FIELDS
+) {
   const firstSentence = getFirstSentence(body);
   const titleAndSentence = `${title || ''} ${firstSentence}`.trim();
   const prompt = template.replace('{text}', titleAndSentence);
@@ -87,12 +106,19 @@ async function extractParties(openai, title, body, template = DEFAULT_TEMPLATE) 
   });
 
   const output = resp.choices[0].message.content.trim();
-  const { acquiror, seller, target, transactionType } = parseOpenAIResponse(output);
+  const parsed = parseFields(output, fields);
+  for (const f of fields) {
+    const camel = toCamel(f);
+    if (['acquiror', 'seller', 'target'].includes(f) && !parsed[camel]) {
+      parsed[camel] = 'N/A';
+    } else if (f === 'transaction_type') {
+      parsed[camel] = parsed[camel] || 'Other';
+    } else if (parsed[camel] === undefined) {
+      parsed[camel] = '';
+    }
+  }
   return {
-    acquiror,
-    seller,
-    target,
-    transactionType,
+    ...parsed,
     prompt,
     firstSentence,
     output
@@ -103,5 +129,8 @@ module.exports = {
   parseOpenAIResponse,
   getFirstSentence,
   extractParties,
-  DEFAULT_TEMPLATE
+  DEFAULT_TEMPLATE,
+  DEFAULT_FIELDS,
+  parseFields,
+  toCamel
 };

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,21 +1,26 @@
-async function getPrompt(db, name, defaultTemplate) {
-  const row = await db.get('SELECT template FROM prompts WHERE name = ?', [name]);
-  if (row && row.template) return row.template;
+async function getPrompt(db, name, defaultTemplate, defaultFields = []) {
+  const row = await db.get('SELECT template, fields FROM prompts WHERE name = ?', [name]);
+  if (row && row.template) {
+    return {
+      template: row.template,
+      fields: row.fields ? row.fields.split(',').map(f => f.trim()).filter(Boolean) : []
+    };
+  }
   if (defaultTemplate !== undefined) {
     const sql = db.raw && db.raw.getDialect && db.raw.getDialect() === 'postgres'
-      ? 'INSERT INTO prompts (name, template) VALUES (?, ?) ON CONFLICT DO NOTHING'
-      : 'INSERT OR IGNORE INTO prompts (name, template) VALUES (?, ?)';
-    await db.run(sql, [name, defaultTemplate]);
-    return defaultTemplate;
+      ? 'INSERT INTO prompts (name, template, fields) VALUES (?, ?, ?) ON CONFLICT DO NOTHING'
+      : 'INSERT OR IGNORE INTO prompts (name, template, fields) VALUES (?, ?, ?)';
+    await db.run(sql, [name, defaultTemplate, defaultFields.join(',')]);
+    return { template: defaultTemplate, fields: defaultFields };
   }
   return null;
 }
 
-async function setPrompt(db, name, template) {
+async function setPrompt(db, name, template, fields = []) {
   const result = await db.run(
-    `INSERT INTO prompts (name, template) VALUES (?, ?)
-       ON CONFLICT(name) DO UPDATE SET template = excluded.template`,
-    [name, template]
+    `INSERT INTO prompts (name, template, fields) VALUES (?, ?, ?)
+       ON CONFLICT(name) DO UPDATE SET template = excluded.template, fields = excluded.fields`,
+    [name, template, Array.isArray(fields) ? fields.join(',') : fields]
   );
   return result.changes;
 }

--- a/public/manage.html
+++ b/public/manage.html
@@ -77,6 +77,7 @@
     <div class="mb-4">
       <label for="extractPartiesPrompt" class="block mb-1 font-medium">Extract Parties Prompt</label>
       <textarea id="extractPartiesPrompt" class="border p-2 w-full h-32"></textarea>
+      <input id="extractPartiesFields" class="border p-2 w-full mt-1" placeholder="Fields (comma separated)" />
       <button id="savePartiesPromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
       <div id="partiesPromptStatus" class="text-sm mt-1"></div>
     </div>
@@ -84,6 +85,7 @@
     <div class="mb-4">
       <label for="summarizeArticlePrompt" class="block mb-1 font-medium">Summarize Article Prompt</label>
       <textarea id="summarizeArticlePrompt" class="border p-2 w-full h-32"></textarea>
+      <input id="summarizeArticleFields" class="border p-2 w-full mt-1" placeholder="Fields (comma separated)" />
       <button id="saveSummarizePromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
       <div id="summarizePromptStatus" class="text-sm mt-1"></div>
     </div>
@@ -91,6 +93,7 @@
     <div class="mb-4">
       <label for="extractValueLocationPrompt" class="block mb-1 font-medium">Value &amp; Location Prompt</label>
       <textarea id="extractValueLocationPrompt" class="border p-2 w-full h-32"></textarea>
+      <input id="extractValueLocationFields" class="border p-2 w-full mt-1" placeholder="Fields (comma separated)" />
       <button id="saveValuePromptBtn" class="mt-2 bg-green-500 text-white px-2 py-1 rounded">Save</button>
       <div id="valuePromptStatus" class="text-sm mt-1"></div>
     </div>
@@ -256,46 +259,75 @@
       });
 
       async function loadPrompts() {
-        const map = {
-          extractPartiesPrompt: 'extractParties',
-          summarizeArticlePrompt: 'summarizeArticle',
-          extractValueLocationPrompt: 'extractValueLocation'
-        };
-        for (const [id, name] of Object.entries(map)) {
-          const res = await fetch(`/prompts/${name}`);
+        const map = [
+          {
+            name: 'extractParties',
+            templateId: 'extractPartiesPrompt',
+            fieldsId: 'extractPartiesFields'
+          },
+          {
+            name: 'summarizeArticle',
+            templateId: 'summarizeArticlePrompt',
+            fieldsId: 'summarizeArticleFields'
+          },
+          {
+            name: 'extractValueLocation',
+            templateId: 'extractValueLocationPrompt',
+            fieldsId: 'extractValueLocationFields'
+          }
+        ];
+        for (const m of map) {
+          const res = await fetch(`/prompts/${m.name}`);
           if (!res.ok) continue;
-          const { template } = await res.json();
-          const el = document.getElementById(id);
-          if (el) el.value = template || '';
+          const { template, fields = [] } = await res.json();
+          const tEl = document.getElementById(m.templateId);
+          if (tEl) tEl.value = template || '';
+          const fEl = document.getElementById(m.fieldsId);
+          if (fEl) fEl.value = fields.join(', ');
         }
       }
 
       document.getElementById('savePartiesPromptBtn').addEventListener('click', async () => {
         const template = document.getElementById('extractPartiesPrompt').value;
+        const fields = document
+          .getElementById('extractPartiesFields')
+          .value.split(',')
+          .map(f => f.trim())
+          .filter(Boolean);
         await fetch('/prompts/extractParties', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ template })
+          body: JSON.stringify({ template, fields })
         });
         document.getElementById('partiesPromptStatus').textContent = 'Saved';
       });
 
       document.getElementById('saveSummarizePromptBtn').addEventListener('click', async () => {
         const template = document.getElementById('summarizeArticlePrompt').value;
+        const fields = document
+          .getElementById('summarizeArticleFields')
+          .value.split(',')
+          .map(f => f.trim())
+          .filter(Boolean);
         await fetch('/prompts/summarizeArticle', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ template })
+          body: JSON.stringify({ template, fields })
         });
         document.getElementById('summarizePromptStatus').textContent = 'Saved';
       });
 
       document.getElementById('saveValuePromptBtn').addEventListener('click', async () => {
         const template = document.getElementById('extractValueLocationPrompt').value;
+        const fields = document
+          .getElementById('extractValueLocationFields')
+          .value.split(',')
+          .map(f => f.trim())
+          .filter(Boolean);
         await fetch('/prompts/extractValueLocation', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ template })
+          body: JSON.stringify({ template, fields })
         });
         document.getElementById('valuePromptStatus').textContent = 'Saved';
       });

--- a/test/enrichment/extractParties.test.js
+++ b/test/enrichment/extractParties.test.js
@@ -35,3 +35,26 @@ test('handles invalid OpenAI JSON', async () => {
   assert.equal(result.target, 'N/A');
   assert.equal(result.transactionType, 'Other');
 });
+
+test('supports custom fields list', async () => {
+  const mockOpenAI = {
+    chat: {
+      completions: {
+        create: async () => ({
+          choices: [{ message: { content: '{"acquiror":"Acme","deal_value":"$5M"}' } }]
+        })
+      }
+    }
+  };
+  const body = 'Acme Corp. today announced financing of $5M.';
+  const fields = ['acquiror', 'deal_value'];
+  const result = await extractParties(
+    mockOpenAI,
+    'Acme financing',
+    body,
+    undefined,
+    fields
+  );
+  assert.equal(result.acquiror, 'Acme');
+  assert.equal(result.dealValue, '$5M');
+});


### PR DESCRIPTION
## Summary
- add inputs to manage prompts' fields
- load and save prompt fields via `/prompts` API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684632f992b4833186461cd225117a44