### PR TITLE
Add currency column for deal value

### DIFF
--- a/public/enriched.html
+++ b/public/enriched.html
@@ -59,7 +59,8 @@
           <th class="border px-2 py-1 w-1/3">Summary</th>
           <th class="border px-2 py-1">Clairfield Sector / Industry</th>
           <th class="border px-2 py-1">Location</th>
-          <th class="border px-2 py-1">Deal Size</th>
+          <th class="border px-2 py-1">Deal Value _basecurrency</th>
+          <th class="border px-2 py-1">Currency</th>
           <th class="border px-2 py-1">Completed</th>
           <th class="border px-2 py-1">Text</th>
         </tr>
@@ -122,6 +123,15 @@
         return num;
       }
 
+      function extractCurrency(str) {
+        if (!str) return '';
+        if (str.includes('$')) return 'USD';
+        if (str.includes('€')) return 'EUR';
+        if (str.includes('£')) return 'GBP';
+        const m = str.match(/\b(USD|EUR|GBP|JPY|CNY|CAD|AUD)\b/i);
+        return m ? m[1].toUpperCase() : '';
+      }
+
       function valueBucket(str) {
         const val = parseDealValueMillions(str);
         if (val == null) return 'Undisclosed';
@@ -167,6 +177,7 @@
             `<td class="border px-2 py-1">${sectorHtml}</td>` +
             `<td class="border px-2 py-1">${a.location || ''}</td>` +
             `<td class="border px-2 py-1">${a.deal_value || ''}</td>` +
+            `<td class="border px-2 py-1">${extractCurrency(a.deal_value)}</td>` +
             `<td class="border px-2 py-1">${completedHtml}</td>` +
             `<td class="border px-2 py-1"><div class="article-body ${hiddenClass}">${bodyHtml}</div></td>`;
           tbody.appendChild(tr);

--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -106,7 +106,8 @@
           <th class="border px-2 py-1 w-1/3">Summary</th>
           <th class="border px-2 py-1">Clairfield Sector / Industry</th>
           <th class="border px-2 py-1">Location</th>
-          <th class="border px-2 py-1">Deal Size</th>
+          <th class="border px-2 py-1">Deal Value _basecurrency</th>
+          <th class="border px-2 py-1">Currency</th>
         </tr>
       </thead>
       <tbody id="articlesBody"></tbody>
@@ -162,6 +163,15 @@
         let num = parseFloat(m[1]);
         if (/b|bn|billion/i.test(lower)) num *= 1000;
         return num;
+      }
+
+      function extractCurrency(str) {
+        if (!str) return "";
+        if (str.includes("$")) return "USD";
+        if (str.includes("€")) return "EUR";
+        if (str.includes("£")) return "GBP";
+        const m = str.match(/\b(USD|EUR|GBP|JPY|CNY|CAD|AUD)\b/i);
+        return m ? m[1].toUpperCase() : "";
       }
 
       function valueBucket(str) {
@@ -246,7 +256,8 @@
             `<td class="border px-2 py-1 w-1/3">${summary}</td>` +
             `<td class="border px-2 py-1">${sectorHtml}</td>` +
             `<td class="border px-2 py-1">${a.location || ""}</td>` +
-            `<td class="border px-2 py-1">${a.deal_value || ""}</td>`;
+            `<td class="border px-2 py-1">${a.deal_value || ""}</td>` +
+            `<td class="border px-2 py-1">${extractCurrency(a.deal_value)}</td>`;
           tbody.appendChild(tr);
         });
       }


### PR DESCRIPTION
## Summary
- rename table heading from Deal Size to Deal Value _basecurrency
- add a Currency column in article tables
- parse currency from `deal_value` strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684635fc14b4833195451c70a29f58c6