### PR TITLE
Add dev/prod startup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,21 @@ npm install
 
 ## Running the server
 
-Start the server with:
+Start the server in either development or production mode:
 
 ```bash
-npm start
+npm run dev  # sets NODE_ENV=development
+npm run prod # sets NODE_ENV=production
 ```
 
-The server listens on the port defined by `PORT` or defaults to `3000`.
+The default `npm start` command still runs `index.js` without setting
+`NODE_ENV`. The server listens on the port defined by `PORT` or defaults to `3000`.
 
 ### Environment variables
 
 - `OPENAI_API_KEY` – required for enrichment endpoints
 - `PORT` – optional port number (defaults to `3000`)
-- `NODE_ENV` – set to `production` to use Postgres
+- `NODE_ENV` – automatically set by the scripts above; `production` uses Postgres
 - `DATABASE_URL` – Postgres connection string (required in production)
 - `DEBUG` – set to `1` to log detailed DB operations
 
@@ -60,7 +62,7 @@ At the time of writing all **14** tests pass.
 
 ```bash
 # start on a different port
-PORT=4000 npm start
+PORT=4000 npm run dev
 ```
 
 ## Keyword filters

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test",
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev": "NODE_ENV=development node index.js",
+    "prod": "NODE_ENV=production node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `dev` and `prod` npm scripts
- document how to start the server in each mode
- update example command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684638c39524833199b166ee7cc89310