### PR TITLE
Extend enrichment info and summary

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,12 @@ async function initDb() {
     acquiror TEXT,
     seller TEXT,
     target TEXT,
+    about_acquiror TEXT,
+    about_seller TEXT,
+    about_target TEXT,
+    acquiror_hq TEXT,
+    seller_hq TEXT,
+    target_hq TEXT,
     deal_value TEXT,
     currency TEXT,
     industry TEXT,
@@ -174,14 +180,14 @@ async function initDb() {
       'INSERT INTO prompts (name, template, fields) VALUES (?, ?, ?)',
       [
         'summarizeArticle',
-        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Respond with JSON {"summary":"...","sector":"...","industry":"..."}. Text: "{text}"',
-        'summary,sector,industry'
+        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and list each party\'s headquarters location. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"',
+        'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_hq,target_hq,seller_hq'
       ]
     );
   } else if (!sumRow.fields) {
     await configDb.run(
       'UPDATE prompts SET fields = ? WHERE name = ?',
-      ['summary,sector,industry', 'summarizeArticle']
+      ['summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_hq,target_hq,seller_hq', 'summarizeArticle']
     );
   }
 
@@ -244,6 +250,30 @@ async function initDb() {
   const hasCurrency = await hasColumn(db, 'article_enrichments', 'currency');
   if (!hasCurrency) {
     await db.run('ALTER TABLE article_enrichments ADD COLUMN currency TEXT');
+  }
+  const hasAboutAcq = await hasColumn(db, 'article_enrichments', 'about_acquiror');
+  if (!hasAboutAcq) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN about_acquiror TEXT');
+  }
+  const hasAboutSeller = await hasColumn(db, 'article_enrichments', 'about_seller');
+  if (!hasAboutSeller) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN about_seller TEXT');
+  }
+  const hasAboutTarget = await hasColumn(db, 'article_enrichments', 'about_target');
+  if (!hasAboutTarget) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN about_target TEXT');
+  }
+  const hasAcqHq = await hasColumn(db, 'article_enrichments', 'acquiror_hq');
+  if (!hasAcqHq) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN acquiror_hq TEXT');
+  }
+  const hasSellerHq = await hasColumn(db, 'article_enrichments', 'seller_hq');
+  if (!hasSellerHq) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN seller_hq TEXT');
+  }
+  const hasTargetHq = await hasColumn(db, 'article_enrichments', 'target_hq');
+  if (!hasTargetHq) {
+    await db.run('ALTER TABLE article_enrichments ADD COLUMN target_hq TEXT');
   }
 
   await configDb.run(`CREATE TABLE IF NOT EXISTS sources (

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -3,7 +3,7 @@ const appendLog = require('./appendLog');
 const { classifySector } = require('../classifySector');
 const { markCompleted, getCompleted } = require('./steps');
 
-const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Respond with JSON {"summary":"...","sector":"...","industry":"..."}. Text: "{text}"`;
+const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and list each party's headquarters location. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"`;
 
 async function summarizeArticle(articleDb, configDb, openai, id) {
   const row = await articleDb.get(
@@ -22,11 +22,11 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
     throw new Error('Article text not found');
   }
 
-  const { template, fields = ['summary', 'sector', 'industry'] } = await getPrompt(
+  const { template, fields = ['summary', 'sector', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq'] } = await getPrompt(
     configDb,
     'summarizeArticle',
     DEFAULT_TEMPLATE,
-    ['summary', 'sector', 'industry']
+    ['summary', 'sector', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq']
   );
   const prompt = template.replace('{text}', row.body);
 
@@ -40,10 +40,23 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
   let summary = '';
   let industry = '';
   let sector = '';
+  let aboutAcquiror = '';
+  let aboutSeller = '';
+  let aboutTarget = '';
+  let acquirorHq = '';
+  let sellerHq = '';
+  let targetHq = '';
   try {
     const parsed = JSON.parse(output);
     if (parsed.summary) summary = parsed.summary;
     if (parsed.industry) industry = parsed.industry;
+    if (parsed.sector) sector = parsed.sector;
+    aboutAcquiror = parsed.about_acquiror || parsed.aboutAcquiror || '';
+    aboutSeller = parsed.about_seller || parsed.aboutSeller || '';
+    aboutTarget = parsed.about_target || parsed.aboutTarget || '';
+    acquirorHq = parsed.acquiror_hq || parsed.acquirorHq || '';
+    sellerHq = parsed.seller_hq || parsed.sellerHq || '';
+    targetHq = parsed.target_hq || parsed.targetHq || '';
   } catch (e) {
     // ignore parse errors
   }
@@ -57,10 +70,33 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
   }
 
   await articleDb.run(
-    `INSERT INTO article_enrichments (article_id, summary, sector, industry)
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT(article_id) DO UPDATE SET summary = excluded.summary, sector = excluded.sector, industry = excluded.industry`,
-    [id, summary, sector, industry]
+    `INSERT INTO article_enrichments (
+        article_id, summary, sector, industry,
+        about_acquiror, about_seller, about_target,
+        acquiror_hq, seller_hq, target_hq
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(article_id) DO UPDATE SET
+         summary = excluded.summary,
+         sector = excluded.sector,
+         industry = excluded.industry,
+         about_acquiror = excluded.about_acquiror,
+         about_seller = excluded.about_seller,
+         about_target = excluded.about_target,
+         acquiror_hq = excluded.acquiror_hq,
+         seller_hq = excluded.seller_hq,
+         target_hq = excluded.target_hq`,
+    [
+      id,
+      summary,
+      sector,
+      industry,
+      aboutAcquiror,
+      aboutSeller,
+      aboutTarget,
+      acquirorHq,
+      sellerHq,
+      targetHq
+    ]
   );
 
   await appendLog(articleDb, id, `Summarized article with sector "${sector}"`);
@@ -69,7 +105,20 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
   const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 
-  return { summary, sector, industry, prompt, output, completed: completed.join(',') };
+  return {
+    summary,
+    sector,
+    industry,
+    aboutAcquiror,
+    aboutSeller,
+    aboutTarget,
+    acquirorHq,
+    sellerHq,
+    targetHq,
+    prompt,
+    output,
+    completed: completed.join(',')
+  };
 }
 
 module.exports = summarizeArticle;

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -117,6 +117,8 @@ router.get('/enrich-list', async (req, res) => {
   const query = `
     SELECT DISTINCT a.id, a.title, a.description, a.time, a.link,
            ae.body, ae.acquiror, ae.seller, ae.target,
+           ae.about_acquiror, ae.about_seller, ae.about_target,
+           ae.acquiror_hq, ae.seller_hq, ae.target_hq,
            ae.deal_value, ae.currency, ae.location, ae.article_date,
            ae.transaction_type, ae.embedding, ae.log,
            ae.summary, ae.sector, ae.industry
@@ -170,6 +172,8 @@ router.get('/enriched-list', async (req, res) => {
     `SELECT a.id, a.title, a.description, a.time, a.link,
             ${agg} as filter_ids,
             ae.body, ae.acquiror, ae.seller, ae.target,
+            ae.about_acquiror, ae.about_seller, ae.about_target,
+            ae.acquiror_hq, ae.seller_hq, ae.target_hq,
             ae.deal_value, ae.currency, ae.location, ae.article_date,
             ae.transaction_type, ae.log,
             ae.summary, ae.sector, ae.industry
@@ -179,6 +183,8 @@ router.get('/enriched-list', async (req, res) => {
       ${includeAll ? '' : 'WHERE ae.body IS NOT NULL AND ae.embedding IS NOT NULL'}
       GROUP BY a.id, a.title, a.description, a.time, a.link,
                ae.body, ae.acquiror, ae.seller, ae.target,
+               ae.about_acquiror, ae.about_seller, ae.about_target,
+               ae.acquiror_hq, ae.seller_hq, ae.target_hq,
                ae.deal_value, ae.currency, ae.location, ae.article_date,
                ae.transaction_type, ae.log,
                ae.summary, ae.sector, ae.industry
@@ -279,10 +285,24 @@ router.post('/:id/summarize', async (req, res) => {
   try {
     await processArticle(id, ['summary']);
     const row = await db.get(
-      'SELECT summary, sector, industry FROM article_enrichments WHERE article_id = ?',
+      `SELECT summary, sector, industry,
+              about_acquiror, about_seller, about_target,
+              acquiror_hq, seller_hq, target_hq
+         FROM article_enrichments WHERE article_id = ?`,
       [id]
     );
-    res.json({ success: true, summary: row.summary, sector: row.sector, industry: row.industry });
+    res.json({
+      success: true,
+      summary: row.summary,
+      sector: row.sector,
+      industry: row.industry,
+      aboutAcquiror: row.about_acquiror,
+      aboutSeller: row.about_seller,
+      aboutTarget: row.about_target,
+      acquirorHq: row.acquiror_hq,
+      sellerHq: row.seller_hq,
+      targetHq: row.target_hq
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to summarize article' });


### PR DESCRIPTION
## Summary
- add extra enrichment fields for party descriptions and HQ locations
- update DB migrations and prompt defaults
- extend summarization step to capture and store the new info
- expose new columns via article routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684642e92ec88331844bb77cd6d982cf