### PR TITLE
Use embedding vectors for sector classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Newsly
 
 Newsly is a small Express application that scrapes news sources and stores articles in a database managed via [Sequelize](https://sequelize.org/). Optional enrichment tasks use the OpenAI API to extract M&A details. When extracting the acquiror, seller and target, the same request also classifies whether the article is about an "M&A" transaction, a "Financing" or "Other".
-Articles can also be summarized with sector and industry labels using GPT.
+Articles can also be summarized with GPT, which provides the industry label. The Clairfield sector is derived separately using the embedding-based classifier.
 
 ## Prerequisites
 

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -3,7 +3,7 @@ const appendLog = require('./appendLog');
 const { classifySector } = require('../classifySector');
 const { markCompleted, getCompleted } = require('./steps');
 
-const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and list each party's headquarters location. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"`;
+const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and list each party's headquarters location. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"`;
 
 async function summarizeArticle(articleDb, configDb, openai, id) {
   const row = await articleDb.get(
@@ -22,11 +22,11 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
     throw new Error('Article text not found');
   }
 
-  const { template, fields = ['summary', 'sector', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq'] } = await getPrompt(
+  const { template, fields = ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq'] } = await getPrompt(
     configDb,
     'summarizeArticle',
     DEFAULT_TEMPLATE,
-    ['summary', 'sector', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq']
+    ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq']
   );
   const prompt = template.replace('{text}', row.body);
 
@@ -50,7 +50,6 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
     const parsed = JSON.parse(output);
     if (parsed.summary) summary = parsed.summary;
     if (parsed.industry) industry = parsed.industry;
-    if (parsed.sector) sector = parsed.sector;
     aboutAcquiror = parsed.about_acquiror || parsed.aboutAcquiror || '';
     aboutSeller = parsed.about_seller || parsed.aboutSeller || '';
     aboutTarget = parsed.about_target || parsed.aboutTarget || '';
@@ -61,7 +60,7 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
     // ignore parse errors
   }
 
-  if (!sector && embeddingVec) {
+  if (embeddingVec) {
     try {
       sector = await classifySector(openai, embeddingVec);
     } catch (e) {


### PR DESCRIPTION
## Summary
- remove sector reference from the summarize prompt
- always compute the Clairfield sector using `classifySector`
- update README to describe how sector is derived

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846e4517a988331bfa86655ed0fb044