### PR TITLE
Stream enrichment steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -528,6 +528,9 @@ app.get('/scrape-enrich-stream', async (req, res) => {
     addLog(null, msg);
     res.write(`data: ${msg}\n\n`);
   };
+  const sendStep = (id, step) => {
+    res.write(`event: step\ndata: ${JSON.stringify({ id, step })}\n\n`);
+  };
 
   try {
     const sources = await configDb.all('SELECT * FROM sources');
@@ -589,7 +592,7 @@ app.get('/scrape-enrich-stream', async (req, res) => {
         return res.end();
       }
       try {
-        await processArticle(id);
+        await processArticle(id, undefined, [], sendStep);
         count++;
         enrichedTotal++;
         send(`Enriched ${count}/${totalToEnrich}`);

--- a/lib/enrichment/extractDateLocation.js
+++ b/lib/enrichment/extractDateLocation.js
@@ -5,7 +5,8 @@ const appendLog = require('./appendLog');
 const { markCompleted, getCompleted } = require('./steps');
 const normalizeDate = require('../normalizeDate');
 
-async function run(articleDb, configDb, id) {
+async function run(articleDb, configDb, id, progress) {
+  progress = typeof progress === 'function' ? progress : null;
   const article = await articleDb.get(
     'SELECT link, time, created_at FROM articles WHERE id = ?',
     [id]
@@ -75,8 +76,14 @@ async function run(articleDb, configDb, id) {
 
   await appendLog(articleDb, id, `Extracted date "${formattedDate || date}" and location "${location}"`);
 
-  if (formattedDate || date) await markCompleted(articleDb, id, 'date');
-  if (location) await markCompleted(articleDb, id, 'location');
+  if (formattedDate || date) {
+    await markCompleted(articleDb, id, 'date');
+    if (progress) await progress(id, 'date');
+  }
+  if (location) {
+    await markCompleted(articleDb, id, 'location');
+    if (progress) await progress(id, 'location');
+  }
   const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 

--- a/lib/enrichment/extractParties.js
+++ b/lib/enrichment/extractParties.js
@@ -9,7 +9,8 @@ const { getPrompt } = require('../prompts');
 const appendLog = require('./appendLog');
 const { markCompleted, getCompleted } = require('./steps');
 
-async function extractParties(articleDb, configDb, openai, id) {
+async function extractParties(articleDb, configDb, openai, id, progress) {
+  progress = typeof progress === 'function' ? progress : null;
   const row = await articleDb.get(
     `SELECT a.title, e.body FROM articles a JOIN article_enrichments e ON a.id = e.article_id WHERE a.id = ?`,
     [id]
@@ -69,6 +70,7 @@ async function extractParties(articleDb, configDb, openai, id) {
   );
 
   await markCompleted(articleDb, id, 'parties');
+  if (progress) await progress(id, 'parties');
   const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 

--- a/lib/enrichment/extractValueAndLocation.js
+++ b/lib/enrichment/extractValueAndLocation.js
@@ -4,7 +4,8 @@ const { markCompleted, getCompleted } = require('./steps');
 
 const DEFAULT_TEMPLATE = `Extract the transaction value in US dollars from the article text if mentioned. If no value is mentioned, respond with "undisclosed". Also review the provided location "{location}" and return a more complete location including country if possible. Respond with JSON {"dealValue":"...","currency":"...","location":"..."}. Text: "{text}"`;
 
-async function extractValueAndLocation(articleDb, configDb, openai, id) {
+async function extractValueAndLocation(articleDb, configDb, openai, id, progress) {
+  progress = typeof progress === 'function' ? progress : null;
   const row = await articleDb.get(
     'SELECT body, location FROM article_enrichments WHERE article_id = ?',
     [id]
@@ -52,6 +53,7 @@ async function extractValueAndLocation(articleDb, configDb, openai, id) {
   await appendLog(articleDb, id, `Extracted value "${dealValue}" (${currency}) and location "${location}"`);
 
   await markCompleted(articleDb, id, 'value');
+  if (progress) await progress(id, 'value');
   const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 

--- a/lib/enrichment/fetchAndStoreBody.js
+++ b/lib/enrichment/fetchAndStoreBody.js
@@ -3,7 +3,8 @@ const cheerio = require('cheerio');
 const appendLog = require('./appendLog');
 const { markCompleted, getCompleted } = require('./steps');
 
-async function fetchAndStoreBody(articleDb, configDb, openai, id) {
+async function fetchAndStoreBody(articleDb, configDb, openai, id, progress) {
+  progress = typeof progress === 'function' ? progress : null;
   const article = await articleDb.get('SELECT link FROM articles WHERE id = ?', [id]);
   if (!article) throw new Error('Article not found');
   if (!article.link) throw new Error('Article link missing');
@@ -103,8 +104,10 @@ async function fetchAndStoreBody(articleDb, configDb, openai, id) {
     [id]
   );
   await markCompleted(articleDb, id, 'body');
+  if (typeof progress === 'function') await progress(id, 'body');
   if (embeddingJson || row.embedding) {
     await markCompleted(articleDb, id, 'embedding');
+    if (typeof progress === 'function') await progress(id, 'embedding');
   }
 
   const completed = await getCompleted(articleDb, id);

--- a/lib/enrichment/pipeline.js
+++ b/lib/enrichment/pipeline.js
@@ -7,39 +7,39 @@ const { runFilters } = require('../filters');
 
 module.exports = (articleDb, configDb, openai) => {
   const stepFns = {
-    filters: (id, logs) => runFilters(articleDb, configDb, [id], logs),
-    body: id => fetchAndStoreBody(articleDb, configDb, openai, id),
-    date: id => extractDateLocation(articleDb, configDb, id),
-    parties: id => extractParties(articleDb, configDb, openai, id),
-    summary: id => summarizeArticle(articleDb, configDb, openai, id),
-    value: id => extractValueAndLocation(articleDb, configDb, openai, id)
+    filters: (id, logs, progress) => runFilters(articleDb, configDb, [id], logs),
+    body: (id, progress) => fetchAndStoreBody(articleDb, configDb, openai, id, progress),
+    date: (id, progress) => extractDateLocation(articleDb, configDb, id, progress),
+    parties: (id, progress) => extractParties(articleDb, configDb, openai, id, progress),
+    summary: (id, progress) => summarizeArticle(articleDb, configDb, openai, id, progress),
+    value: (id, progress) => extractValueAndLocation(articleDb, configDb, openai, id, progress)
   };
 
   const defaultSteps = ['body', 'date', 'parties', 'summary', 'value'];
 
-  return async function processArticle(id, steps = defaultSteps, logs = []) {
+  return async function processArticle(id, steps = defaultSteps, logs = [], progress) {
     let bodyRes = null;
     for (const step of steps) {
       switch (step) {
         case 'filters':
-          await stepFns.filters(id, logs);
+          await stepFns.filters(id, logs, progress);
           break;
         case 'body':
-          bodyRes = await stepFns.body(id);
+          bodyRes = await stepFns.body(id, progress);
           break;
         case 'date':
           // If body step was run and failed to fetch text, skip date extraction
           if (steps.includes('body') && bodyRes && !bodyRes.body) break;
-          await stepFns.date(id);
+          await stepFns.date(id, progress);
           break;
         case 'parties':
-          await stepFns.parties(id);
+          await stepFns.parties(id, progress);
           break;
         case 'summary':
-          await stepFns.summary(id);
+          await stepFns.summary(id, progress);
           break;
         case 'value':
-          await stepFns.value(id);
+          await stepFns.value(id, progress);
           break;
         default:
           // ignore unknown step names

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -5,7 +5,8 @@ const { markCompleted, getCompleted } = require('./steps');
 
 const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and list each party's headquarters location. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"`;
 
-async function summarizeArticle(articleDb, configDb, openai, id) {
+async function summarizeArticle(articleDb, configDb, openai, id, progress) {
+  progress = typeof progress === 'function' ? progress : null;
   const row = await articleDb.get(
     'SELECT body, embedding FROM article_enrichments WHERE article_id = ?',
     [id]
@@ -101,6 +102,7 @@ async function summarizeArticle(articleDb, configDb, openai, id) {
   await appendLog(articleDb, id, `Summarized article with sector "${sector}"`);
 
   await markCompleted(articleDb, id, 'summary');
+  if (progress) await progress(id, 'summary');
   const completed = await getCompleted(articleDb, id);
   await appendLog(articleDb, id, `Updated completed steps: ${completed.join(',')}`);
 

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,21 @@
 
     <div id="scrapeResults" class="mb-2 text-sm"></div>
     <div id="lastScrape" class="mb-2 text-sm"></div>
-    <pre id="scrapeLog" class="mb-4 p-2 text-xs bg-gray-100 whitespace-pre-wrap"></pre>
+    <pre id="scrapeLog" class="mb-2 p-2 text-xs bg-gray-100 whitespace-pre-wrap"></pre>
+    <table id="progressTable" class="mb-4 table-auto w-full border-collapse text-xs">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">Article</th>
+          <th class="border px-2 py-1">Body</th>
+          <th class="border px-2 py-1">Embed</th>
+          <th class="border px-2 py-1">Date</th>
+          <th class="border px-2 py-1">Location</th>
+          <th class="border px-2 py-1">Parties</th>
+          <th class="border px-2 py-1">Summary</th>
+        </tr>
+      </thead>
+      <tbody id="progressBody"></tbody>
+    </table>
 
     <p class="mb-4 text-sm">
       Manage sources and filters on the
@@ -75,6 +89,28 @@
       ];
 
       const enrichSteps = ['body', 'embedding', 'date', 'location', 'parties', 'summary'];
+
+      const progressRows = {};
+      const progressOrder = ['body', 'embedding', 'date', 'location', 'parties', 'summary'];
+      function resetProgress() {
+        const tbody = document.getElementById('progressBody');
+        tbody.innerHTML = '';
+        for (const k in progressRows) delete progressRows[k];
+      }
+      function updateProgress(id, step) {
+        if (!progressOrder.includes(step)) return;
+        let row = progressRows[id];
+        if (!row) {
+          const tbody = document.getElementById('progressBody');
+          row = document.createElement('tr');
+          row.innerHTML = `<td class="border px-2 py-1">${id}</td>` +
+            progressOrder.map(s => `<td data-step="${s}" class="border px-2 py-1 text-center"></td>`).join('');
+          tbody.appendChild(row);
+          progressRows[id] = row;
+        }
+        const cell = row.querySelector(`td[data-step="${step}"]`);
+        if (cell) cell.textContent = '✓';
+      }
 
       function formatTime(text) {
         if (!text) return '';
@@ -134,6 +170,7 @@
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
         log.textContent = '';
+        resetProgress();
         div.textContent = 'Running full pipeline...';
 
         const es = new EventSource('/scrape-enrich-stream');
@@ -141,6 +178,12 @@
           log.textContent += e.data + '\n';
           log.scrollTop = log.scrollHeight;
         };
+        es.addEventListener('step', e => {
+          try {
+            const data = JSON.parse(e.data);
+            updateProgress(data.id, data.step);
+          } catch {}
+        });
         es.addEventListener('done', e => {
           es.close();
           try {
@@ -159,6 +202,7 @@
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
         log.textContent = '';
+        resetProgress();
         div.textContent = 'Running pipeline...';
 
         const formData = new FormData(pipelineForm);
@@ -175,6 +219,12 @@
           log.textContent += e.data + '\n';
           log.scrollTop = log.scrollHeight;
         };
+        es.addEventListener('step', e => {
+          try {
+            const data = JSON.parse(e.data);
+            updateProgress(data.id, data.step);
+          } catch {}
+        });
         es.addEventListener('done', e => {
           es.close();
           try {
@@ -193,6 +243,7 @@
         const log = document.getElementById('scrapeLog');
         const div = document.getElementById('scrapeResults');
         log.textContent = '';
+        resetProgress();
         div.textContent = 'Running pipeline...';
 
         const formData = new FormData(pipelineForm);
@@ -210,6 +261,12 @@
           log.textContent += e.data + '\n';
           log.scrollTop = log.scrollHeight;
         };
+        es.addEventListener('step', e => {
+          try {
+            const data = JSON.parse(e.data);
+            updateProgress(data.id, data.step);
+          } catch {}
+        });
         es.addEventListener('done', e => {
           es.close();
           try {

--- a/routes/pipeline.js
+++ b/routes/pipeline.js
@@ -71,6 +71,7 @@ router.get('/run-stream', async (req, res) => {
   res.flushHeaders();
 
   const send = msg => res.write(`data: ${msg}\n\n`);
+  const sendStep = (id, step) => res.write(`event: step\ndata: ${JSON.stringify({ id, step })}\n\n`);
 
   try {
     let steps = (req.query.steps || '')
@@ -110,7 +111,7 @@ router.get('/run-stream', async (req, res) => {
         if (!missing.length) continue;
       }
       try {
-        await processArticle(id, steps, logs);
+        await processArticle(id, steps, logs, sendStep);
         logs.forEach(send);
         logs.length = 0;
         processed++;


### PR DESCRIPTION
## Summary
- improve SSE pipeline routes to emit step events
- record progress inside enrichment steps
- update pipeline processing logic for progress callbacks
- show progress table on main page and update client JavaScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846e69cc5d08331b5086770c8bc509f