### PR TITLE
Refactor scrape-enrich pipeline

### DIFF
--- a/lib/scrapeFilterEnrich.js
+++ b/lib/scrapeFilterEnrich.js
@@ -1,0 +1,91 @@
+const { runFilters } = require('./filters');
+const { scrapeSource } = require('./scraper');
+const insertArticles = require('./insertArticles');
+const addLog = require('./addLog');
+
+async function scrapeFilterEnrich(db, configDb, processArticle, options = {}) {
+  const {
+    send,
+    sendStep,
+    logs = [],
+    stop = () => false,
+  } = options;
+
+  const isPg = db.raw?.getDialect && db.raw.getDialect() === 'postgres';
+  const output = send || ((msg) => addLog(logs, msg));
+  const stepCb = sendStep || (() => {});
+
+  const sources = await configDb.all('SELECT * FROM sources');
+  output(`Found ${sources.length} sources`);
+
+  let insertedTotal = 0;
+  let enrichedTotal = 0;
+  const details = [];
+  const toEnrich = [];
+
+  for (const source of sources) {
+    if (stop()) {
+      return { stopped: true, inserted: insertedTotal, enriched: enrichedTotal, details, logs };
+    }
+    output(`Fetching ${source.base_url}`);
+    let articles;
+    try {
+      articles = await scrapeSource(source);
+      output(`Loaded ${articles.length} articles from ${source.base_url}`);
+    } catch (e) {
+      output(`Failed to fetch ${source.base_url}: ${e.message}`);
+      continue;
+    }
+
+    const { inserted, insertedIds } = await insertArticles(db, articles, isPg);
+    insertedTotal += inserted;
+    output(`Inserted ${inserted} new articles from ${source.base_url}`);
+    if (insertedIds.length) {
+      output(`New article IDs: ${insertedIds.join(', ')}`);
+    }
+
+    if (insertedIds.length) {
+      await runFilters(db, configDb, insertedIds, logs);
+      logs.forEach(output);
+      logs.length = 0;
+
+      const placeholders = insertedIds.map(() => '?').join(',');
+      const rows = await db.all(
+        `SELECT DISTINCT article_id FROM article_filter_matches WHERE article_id IN (${placeholders})`,
+        insertedIds,
+      );
+      const matchedIds = rows.map((r) => r.article_id);
+      toEnrich.push(...matchedIds);
+    }
+
+    details.push({
+      source_id: source.id,
+      base_url: source.base_url,
+      scraped: articles.length,
+      inserted,
+    });
+  }
+
+  const totalToEnrich = toEnrich.length;
+  output(`Inserted total ${insertedTotal} new articles`);
+  output(`Enriching ${totalToEnrich} articles`);
+  let count = 0;
+  for (const id of toEnrich) {
+    if (stop()) {
+      return { stopped: true, inserted: insertedTotal, enriched: enrichedTotal, details, logs };
+    }
+    try {
+      await processArticle(id, undefined, [], stepCb);
+      count++;
+      enrichedTotal++;
+      output(`Enriched ${count}/${totalToEnrich}`);
+    } catch (e) {
+      output(`Failed to enrich article ${id}: ${e.message}`);
+    }
+  }
+
+  output(`Enriched total ${enrichedTotal} articles`);
+  return { inserted: insertedTotal, enriched: enrichedTotal, details, logs };
+}
+
+module.exports = scrapeFilterEnrich;

--- a/routes/pipelineAdmin.js
+++ b/routes/pipelineAdmin.js
@@ -7,6 +7,7 @@ const { scrapeSource } = require('../lib/scraper');
 const createPipeline = require('../lib/enrichment/pipeline');
 const insertArticles = require('../lib/insertArticles');
 const addLog = require('../lib/addLog');
+const scrapeFilterEnrich = require('../lib/scrapeFilterEnrich');
 const logger = require('../logger');
 
 const router = express.Router();
@@ -67,70 +68,8 @@ router.get('/scrape', async (req, res) => {
 router.get('/scrape-enrich', async (req, res) => {
   const logs = [];
   try {
-    const sources = await configDb.all('SELECT * FROM sources');
-    addLog(logs, `Found ${sources.length} sources`);
-
-    let insertedTotal = 0;
-    let enrichedTotal = 0;
-    const details = [];
-
-    for (const source of sources) {
-      addLog(logs, `Fetching ${source.base_url}`);
-      let articles;
-      try {
-        articles = await scrapeSource(source);
-        addLog(logs, `Loaded ${articles.length} articles from ${source.base_url}`);
-      } catch (e) {
-        addLog(logs, `Failed to fetch ${source.base_url}: ${e.message}`);
-        continue;
-      }
-
-      const { inserted, insertedIds } = await insertArticles(db, articles, isPg);
-      insertedTotal += inserted;
-      addLog(logs, `Inserted ${inserted} new articles from ${source.base_url}`);
-      if (insertedIds.length) {
-        addLog(logs, `New article IDs: ${insertedIds.join(', ')}`);
-      }
-
-      if (insertedIds.length) {
-        await runFilters(db, configDb, insertedIds, logs);
-        const placeholders = insertedIds.map(() => '?').join(',');
-        const rows = await db.all(
-          `SELECT DISTINCT article_id FROM article_filter_matches WHERE article_id IN (${placeholders})`,
-          insertedIds,
-        );
-        const matchedIds = rows.map((r) => r.article_id);
-        const enrichedIds = [];
-        for (const id of matchedIds) {
-          try {
-            await processArticle(id);
-            enrichedTotal++;
-            enrichedIds.push(id);
-          } catch (e) {
-            addLog(logs, `Failed to enrich article ${id}: ${e.message}`);
-          }
-        }
-        if (enrichedIds.length) {
-          addLog(logs, `Enriched article ${enrichedIds.join(', ')}`);
-        }
-      }
-
-      details.push({
-        source_id: source.id,
-        base_url: source.base_url,
-        scraped: articles.length,
-        inserted,
-      });
-    }
-
-    addLog(logs, `Inserted total ${insertedTotal} new articles`);
-    addLog(logs, `Enriched total ${enrichedTotal} articles`);
-    res.json({
-      inserted: insertedTotal,
-      enriched: enrichedTotal,
-      details,
-      logs,
-    });
+    const result = await scrapeFilterEnrich(db, configDb, processArticle, { logs });
+    res.json(result);
   } catch (err) {
     logger.error(err);
     addLog(logs, `Error: ${err.message}`);
@@ -156,75 +95,17 @@ router.get('/scrape-enrich-stream', async (req, res) => {
   };
 
   try {
-    const sources = await configDb.all('SELECT * FROM sources');
-    send(`Found ${sources.length} sources`);
-
-    let insertedTotal = 0;
-    let enrichedTotal = 0;
-
-    const toEnrich = [];
-
-    for (const source of sources) {
-      if (stopPipeline) {
-        send('Pipeline stopped');
-        res.write(`event: done\ndata: ${JSON.stringify({ stopped: true })}\n\n`);
-        return res.end();
-      }
-      send(`Fetching ${source.base_url}`);
-      let articles;
-      try {
-        articles = await scrapeSource(source);
-        send(`Loaded ${articles.length} articles from ${source.base_url}`);
-      } catch (e) {
-        send(`Failed to fetch ${source.base_url}: ${e.message}`);
-        continue;
-      }
-
-      const { inserted, insertedIds } = await insertArticles(db, articles, isPg);
-      insertedTotal += inserted;
-      send(`Inserted ${inserted} new articles from ${source.base_url}`);
-      if (insertedIds.length) {
-        send(`New article IDs: ${insertedIds.join(', ')}`);
-      }
-
-      if (insertedIds.length) {
-        await runFilters(db, configDb, insertedIds, logs);
-        logs.forEach(send);
-        logs.length = 0;
-
-        const placeholders = insertedIds.map(() => '?').join(',');
-        const rows = await db.all(
-          `SELECT DISTINCT article_id FROM article_filter_matches WHERE article_id IN (${placeholders})`,
-          insertedIds,
-        );
-        const matchedIds = rows.map((r) => r.article_id);
-
-        toEnrich.push(...matchedIds);
-      }
+    const result = await scrapeFilterEnrich(db, configDb, processArticle, {
+      send,
+      sendStep,
+      logs,
+      stop: () => stopPipeline,
+    });
+    if (result.stopped) {
+      res.write(`event: done\ndata: ${JSON.stringify({ stopped: true })}\n\n`);
+    } else {
+      res.write(`event: done\ndata: ${JSON.stringify({ inserted: result.inserted, enriched: result.enriched })}\n\n`);
     }
-
-    const totalToEnrich = toEnrich.length;
-    send(`Inserted total ${insertedTotal} new articles`);
-    send(`Enriching ${totalToEnrich} articles`);
-    let count = 0;
-    for (const id of toEnrich) {
-      if (stopPipeline) {
-        send('Pipeline stopped');
-        res.write(`event: done\ndata: ${JSON.stringify({ stopped: true })}\n\n`);
-        return res.end();
-      }
-      try {
-        await processArticle(id, undefined, [], sendStep);
-        count++;
-        enrichedTotal++;
-        send(`Enriched ${count}/${totalToEnrich}`);
-      } catch (e) {
-        send(`Failed to enrich article ${id}: ${e.message}`);
-      }
-    }
-
-    send(`Enriched total ${enrichedTotal} articles`);
-    res.write(`event: done\ndata: ${JSON.stringify({ inserted: insertedTotal, enriched: enrichedTotal })}\n\n`);
     res.end();
   } catch (err) {
     logger.error(err);


### PR DESCRIPTION
## Summary
- extract duplicated scrape+filter+enrich logic into `lib/scrapeFilterEnrich.js`
- reuse new helper in `/scrape-enrich` and `/scrape-enrich-stream`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847353715748331989420d4295a33fb