### PR TITLE
Update enrichment data to store website URLs

### DIFF
--- a/db/init.js
+++ b/db/init.js
@@ -91,9 +91,9 @@ async function initDb() {
     about_acquiror TEXT,
     about_seller TEXT,
     about_target TEXT,
-    acquiror_hq TEXT,
-    seller_hq TEXT,
-    target_hq TEXT,
+    acquiror_url TEXT,
+    seller_url TEXT,
+    target_url TEXT,
     deal_value TEXT,
     currency TEXT,
     industry TEXT,
@@ -180,13 +180,13 @@ async function initDb() {
       'INSERT INTO prompts (name, template, fields) VALUES (?, ?, ?)',
       [
         'summarizeArticle',
-        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and list each party\'s headquarters location. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"',
-        'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_hq,target_hq,seller_hq'
+        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and include each party\'s website URL if available. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","target_url":"...","seller_url":"..."}. Text: "{text}"',
+        'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,target_url,seller_url'
       ]
     );
   } else if (!sumRow.fields) {
     await configDb.run('UPDATE prompts SET fields = ? WHERE name = ?', [
-      'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_hq,target_hq,seller_hq',
+      'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,target_url,seller_url',
       'summarizeArticle'
     ]);
   }
@@ -225,9 +225,9 @@ async function initDb() {
     'about_acquiror',
     'about_seller',
     'about_target',
-    'acquiror_hq',
-    'seller_hq',
-    'target_hq'
+    'acquiror_url',
+    'seller_url',
+    'target_url'
   ];
 
   for (const col of enrichmentColumns) {

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -3,7 +3,7 @@ const appendLog = require('./appendLog');
 const { classifySector } = require('../classifySector');
 const { markCompleted, getCompleted } = require('./steps');
 
-const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and list each party's headquarters location. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_hq":"...","target_hq":"...","seller_hq":"..."}. Text: "{text}"`;
+const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and include each party's website URL where available. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","target_url":"...","seller_url":"..."}. Text: "{text}"`;
 
 async function summarizeArticle(articleDb, configDb, openai, id, progress) {
   progress = typeof progress === 'function' ? progress : null;
@@ -23,11 +23,11 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     throw new Error('Article text not found');
   }
 
-  const { template, fields = ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq'] } = await getPrompt(
+  const { template, fields = ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'target_url', 'seller_url'] } = await getPrompt(
     configDb,
     'summarizeArticle',
     DEFAULT_TEMPLATE,
-    ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_hq', 'target_hq', 'seller_hq']
+    ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'target_url', 'seller_url']
   );
   const prompt = template.replace('{text}', row.body);
 
@@ -44,9 +44,9 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
   let aboutAcquiror = '';
   let aboutSeller = '';
   let aboutTarget = '';
-  let acquirorHq = '';
-  let sellerHq = '';
-  let targetHq = '';
+  let acquirorUrl = '';
+  let sellerUrl = '';
+  let targetUrl = '';
   try {
     const parsed = JSON.parse(output);
     if (parsed.summary) summary = parsed.summary;
@@ -54,9 +54,9 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     aboutAcquiror = parsed.about_acquiror || parsed.aboutAcquiror || '';
     aboutSeller = parsed.about_seller || parsed.aboutSeller || '';
     aboutTarget = parsed.about_target || parsed.aboutTarget || '';
-    acquirorHq = parsed.acquiror_hq || parsed.acquirorHq || '';
-    sellerHq = parsed.seller_hq || parsed.sellerHq || '';
-    targetHq = parsed.target_hq || parsed.targetHq || '';
+    acquirorUrl = parsed.acquiror_url || parsed.acquirorUrl || '';
+    sellerUrl = parsed.seller_url || parsed.sellerUrl || '';
+    targetUrl = parsed.target_url || parsed.targetUrl || '';
   } catch (e) {
     // ignore parse errors
   }
@@ -73,18 +73,18 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     `INSERT INTO article_enrichments (
         article_id, summary, sector, industry,
         about_acquiror, about_seller, about_target,
-        acquiror_hq, seller_hq, target_hq
+        acquiror_url, seller_url, target_url
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(article_id) DO UPDATE SET
+      ON CONFLICT(article_id) DO UPDATE SET
          summary = excluded.summary,
          sector = excluded.sector,
          industry = excluded.industry,
          about_acquiror = excluded.about_acquiror,
          about_seller = excluded.about_seller,
          about_target = excluded.about_target,
-         acquiror_hq = excluded.acquiror_hq,
-         seller_hq = excluded.seller_hq,
-         target_hq = excluded.target_hq`,
+         acquiror_url = excluded.acquiror_url,
+         seller_url = excluded.seller_url,
+         target_url = excluded.target_url`,
     [
       id,
       summary,
@@ -93,9 +93,9 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
       aboutAcquiror,
       aboutSeller,
       aboutTarget,
-      acquirorHq,
-      sellerHq,
-      targetHq
+      acquirorUrl,
+      sellerUrl,
+      targetUrl
     ]
   );
 
@@ -113,9 +113,9 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     aboutAcquiror,
     aboutSeller,
     aboutTarget,
-    acquirorHq,
-    sellerHq,
-    targetHq,
+    acquirorUrl,
+    sellerUrl,
+    targetUrl,
     prompt,
     output,
     completed: completed.join(',')

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -118,7 +118,7 @@ router.get('/enrich-list', async (req, res) => {
     SELECT DISTINCT a.id, a.title, a.description, a.time, a.link,
            ae.body, ae.acquiror, ae.seller, ae.target,
            ae.about_acquiror, ae.about_seller, ae.about_target,
-           ae.acquiror_hq, ae.seller_hq, ae.target_hq,
+           ae.acquiror_url, ae.seller_url, ae.target_url,
            ae.deal_value, ae.currency, ae.location, ae.article_date,
            ae.transaction_type, ae.embedding, ae.log,
            ae.summary, ae.sector, ae.industry
@@ -173,7 +173,7 @@ router.get('/enriched-list', async (req, res) => {
             ${agg} as filter_ids,
             ae.body, ae.acquiror, ae.seller, ae.target,
             ae.about_acquiror, ae.about_seller, ae.about_target,
-            ae.acquiror_hq, ae.seller_hq, ae.target_hq,
+            ae.acquiror_url, ae.seller_url, ae.target_url,
             ae.deal_value, ae.currency, ae.location, ae.article_date,
             ae.transaction_type, ae.log,
             ae.summary, ae.sector, ae.industry
@@ -184,7 +184,7 @@ router.get('/enriched-list', async (req, res) => {
       GROUP BY a.id, a.title, a.description, a.time, a.link,
                ae.body, ae.acquiror, ae.seller, ae.target,
                ae.about_acquiror, ae.about_seller, ae.about_target,
-               ae.acquiror_hq, ae.seller_hq, ae.target_hq,
+               ae.acquiror_url, ae.seller_url, ae.target_url,
                ae.deal_value, ae.currency, ae.location, ae.article_date,
                ae.transaction_type, ae.log,
                ae.summary, ae.sector, ae.industry
@@ -287,7 +287,7 @@ router.post('/:id/summarize', async (req, res) => {
     const row = await db.get(
       `SELECT summary, sector, industry,
               about_acquiror, about_seller, about_target,
-              acquiror_hq, seller_hq, target_hq
+              acquiror_url, seller_url, target_url
          FROM article_enrichments WHERE article_id = ?`,
       [id]
     );
@@ -299,9 +299,9 @@ router.post('/:id/summarize', async (req, res) => {
       aboutAcquiror: row.about_acquiror,
       aboutSeller: row.about_seller,
       aboutTarget: row.about_target,
-      acquirorHq: row.acquiror_hq,
-      sellerHq: row.seller_hq,
-      targetHq: row.target_hq
+      acquirorUrl: row.acquiror_url,
+      sellerUrl: row.seller_url,
+      targetUrl: row.target_url
     });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- change enrichment table columns from *_hq to *_url
- update default summarization prompt to request website URLs
- adjust enrichment logic and API routes for the new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68473e2d75c0833194c1106fa524a564