### PR TITLE
Fix article fetch on This Week page

### DIFF
--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -381,7 +381,8 @@
       }
 
       async function loadArticles() {
-        const res = await fetch("/articles/enriched-list?level=full");
+        // Use level=all to include partially enriched articles
+        const res = await fetch("/articles/enriched-list?level=all");
         const data = await res.json();
         allArticles = data.articles.map((a) => ({
           ...a,


### PR DESCRIPTION
## Summary
- load all enriched articles on `thisweek.html` instead of only fully complete ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847438207988331b0ee847bcc537ec9