### PR TITLE
Refactor cosine similarity utility

### DIFF
--- a/lib/classifySector.js
+++ b/lib/classifySector.js
@@ -7,20 +7,7 @@ const CLAIRFIELD_SECTORS = [
   'Software, tech & digital'
 ];
 
-function cosineSimilarity(a, b) {
-  let dot = 0;
-  let normA = 0;
-  let normB = 0;
-  for (let i = 0; i < a.length; i++) {
-    const x = a[i];
-    const y = b[i];
-    dot += x * y;
-    normA += x * x;
-    normB += y * y;
-  }
-  if (!normA || !normB) return 0;
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}
+const cosineSimilarity = require('../utils/cosineSimilarity');
 
 function classifySectorFromVectors(articleVec, sectorVectors, names = CLAIRFIELD_SECTORS) {
   if (!articleVec || !Array.isArray(sectorVectors)) return '';

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -5,20 +5,7 @@ const configDb = require('../configDb');
 const { getCompleted } = require('../lib/enrichment/steps');
 const createPipeline = require('../lib/enrichment/pipeline');
 
-function cosineSimilarity(a, b) {
-  let dot = 0;
-  let normA = 0;
-  let normB = 0;
-  for (let i = 0; i < a.length; i++) {
-    const x = a[i];
-    const y = b[i];
-    dot += x * y;
-    normA += x * x;
-    normB += y * y;
-  }
-  if (!normA || !normB) return 0;
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}
+const cosineSimilarity = require('../utils/cosineSimilarity');
 
 const router = express.Router();
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });

--- a/utils/cosineSimilarity.js
+++ b/utils/cosineSimilarity.js
@@ -1,0 +1,16 @@
+function cosineSimilarity(a, b) {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    dot += x * y;
+    normA += x * x;
+    normB += y * y;
+  }
+  if (!normA || !normB) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+module.exports = cosineSimilarity;


### PR DESCRIPTION
## Summary
- extract cosine similarity into `utils/cosineSimilarity.js`
- use shared utility in `lib/classifySector.js` and `routes/articles.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fd3a726288331b541805efebe72ab