### PR TITLE
Add location details to summaries and tombstones

### DIFF
--- a/db/init.js
+++ b/db/init.js
@@ -92,8 +92,11 @@ async function initDb() {
     about_seller TEXT,
     about_target TEXT,
     acquiror_url TEXT,
+    acquiror_location TEXT,
     seller_url TEXT,
+    seller_location TEXT,
     target_url TEXT,
+    target_location TEXT,
     deal_value TEXT,
     currency TEXT,
     industry TEXT,
@@ -180,13 +183,13 @@ async function initDb() {
       'INSERT INTO prompts (name, template, fields) VALUES (?, ?, ?)',
       [
         'summarizeArticle',
-        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and include each party\'s website URL if available. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","target_url":"...","seller_url":"..."}. Text: "{text}"',
-        'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,target_url,seller_url'
+        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and include each party\'s website URL if available. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","acquiror_location":"...","target_url":"...","target_location":"...","seller_url":"...","seller_location":"..."}. Text: "{text}"',
+        'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,acquiror_location,target_url,target_location,seller_url,seller_location'
       ]
     );
   } else if (!sumRow.fields) {
     await configDb.run('UPDATE prompts SET fields = ? WHERE name = ?', [
-      'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,target_url,seller_url',
+      'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,acquiror_location,target_url,target_location,seller_url,seller_location',
       'summarizeArticle'
     ]);
   }
@@ -226,8 +229,11 @@ async function initDb() {
     'about_seller',
     'about_target',
     'acquiror_url',
+    'acquiror_location',
     'seller_url',
-    'target_url'
+    'seller_location',
+    'target_url',
+    'target_location'
   ];
 
   for (const col of enrichmentColumns) {

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -3,7 +3,7 @@ const appendLog = require('./appendLog');
 const { classifySector } = require('../classifySector');
 const { markCompleted, getCompleted } = require('./steps');
 
-const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and include each party's website URL where available. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","target_url":"...","seller_url":"..."}. Text: "{text}"`;
+const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and include each party's website URL where available. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","acquiror_location":"...","target_url":"...","target_location":"...","seller_url":"...","seller_location":"..."}. Text: "{text}"`;
 
 async function summarizeArticle(articleDb, configDb, openai, id, progress) {
   progress = typeof progress === 'function' ? progress : null;
@@ -23,11 +23,11 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     throw new Error('Article text not found');
   }
 
-  const { template, fields = ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'target_url', 'seller_url'] } = await getPrompt(
+  const { template, fields = ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'acquiror_location', 'target_url', 'target_location', 'seller_url', 'seller_location'] } = await getPrompt(
     configDb,
     'summarizeArticle',
     DEFAULT_TEMPLATE,
-    ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'target_url', 'seller_url']
+    ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'acquiror_location', 'target_url', 'target_location', 'seller_url', 'seller_location']
   );
   const prompt = template.replace('{text}', row.body);
 
@@ -47,6 +47,9 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
   let acquirorUrl = '';
   let sellerUrl = '';
   let targetUrl = '';
+  let acquirorLocation = '';
+  let sellerLocation = '';
+  let targetLocation = '';
   try {
     const parsed = JSON.parse(output);
     if (parsed.summary) summary = parsed.summary;
@@ -57,6 +60,9 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     acquirorUrl = parsed.acquiror_url || parsed.acquirorUrl || '';
     sellerUrl = parsed.seller_url || parsed.sellerUrl || '';
     targetUrl = parsed.target_url || parsed.targetUrl || '';
+    acquirorLocation = parsed.acquiror_location || parsed.acquirorLocation || '';
+    sellerLocation = parsed.seller_location || parsed.sellerLocation || '';
+    targetLocation = parsed.target_location || parsed.targetLocation || '';
   } catch (e) {
     // ignore parse errors
   }
@@ -73,8 +79,10 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     `INSERT INTO article_enrichments (
         article_id, summary, sector, industry,
         about_acquiror, about_seller, about_target,
-        acquiror_url, seller_url, target_url
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        acquiror_url, acquiror_location,
+        seller_url, seller_location,
+        target_url, target_location
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(article_id) DO UPDATE SET
          summary = excluded.summary,
          sector = excluded.sector,
@@ -83,8 +91,11 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
          about_seller = excluded.about_seller,
          about_target = excluded.about_target,
          acquiror_url = excluded.acquiror_url,
+         acquiror_location = excluded.acquiror_location,
          seller_url = excluded.seller_url,
-         target_url = excluded.target_url`,
+         seller_location = excluded.seller_location,
+         target_url = excluded.target_url,
+         target_location = excluded.target_location`,
     [
       id,
       summary,
@@ -94,8 +105,11 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
       aboutSeller,
       aboutTarget,
       acquirorUrl,
+      acquirorLocation,
       sellerUrl,
-      targetUrl
+      sellerLocation,
+      targetUrl,
+      targetLocation
     ]
   );
 
@@ -114,8 +128,11 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     aboutSeller,
     aboutTarget,
     acquirorUrl,
+    acquirorLocation,
     sellerUrl,
+    sellerLocation,
     targetUrl,
+    targetLocation,
     prompt,
     output,
     completed: completed.join(',')

--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -70,7 +70,18 @@ export function createTombstone(article) {
     ? article.transaction_type.trim()
     : '';
   const txType = txTypeRaw ? escapeHtml(txTypeRaw) : '';
-  const location = article.location && article.location !== 'N/A' ? escapeHtml(article.location) : '';
+  const tLoc = article.target_location || article.targetLocation || '';
+  const aLoc = article.acquiror_location || article.acquirorLocation || '';
+  let location = '';
+  if (tLoc && aLoc) {
+    location = `${escapeHtml(tLoc)} / ${escapeHtml(aLoc)}`;
+  } else if (tLoc) {
+    location = escapeHtml(tLoc);
+  } else if (aLoc) {
+    location = escapeHtml(aLoc);
+  } else if (article.location && article.location !== 'N/A') {
+    location = escapeHtml(article.location);
+  }
   const flag = flagFromLocation(location);
 
   const bodyLines = [];

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -105,7 +105,9 @@ router.get('/enrich-list', async (req, res) => {
     SELECT DISTINCT a.id, a.title, a.description, a.time, a.link,
            ae.body, ae.acquiror, ae.seller, ae.target,
            ae.about_acquiror, ae.about_seller, ae.about_target,
-           ae.acquiror_url, ae.seller_url, ae.target_url,
+           ae.acquiror_url, ae.acquiror_location,
+           ae.seller_url, ae.seller_location,
+           ae.target_url, ae.target_location,
            ae.deal_value, ae.currency, ae.location, ae.article_date,
            ae.transaction_type, ae.embedding, ae.log,
            ae.summary, ae.sector, ae.industry
@@ -160,7 +162,9 @@ router.get('/enriched-list', async (req, res) => {
             ${agg} as filter_ids,
             ae.body, ae.acquiror, ae.seller, ae.target,
             ae.about_acquiror, ae.about_seller, ae.about_target,
-            ae.acquiror_url, ae.seller_url, ae.target_url,
+            ae.acquiror_url, ae.acquiror_location,
+            ae.seller_url, ae.seller_location,
+            ae.target_url, ae.target_location,
             ae.deal_value, ae.currency, ae.location, ae.article_date,
             ae.transaction_type, ae.log,
             ae.summary, ae.sector, ae.industry
@@ -171,7 +175,9 @@ router.get('/enriched-list', async (req, res) => {
       GROUP BY a.id, a.title, a.description, a.time, a.link,
                ae.body, ae.acquiror, ae.seller, ae.target,
                ae.about_acquiror, ae.about_seller, ae.about_target,
-               ae.acquiror_url, ae.seller_url, ae.target_url,
+               ae.acquiror_url, ae.acquiror_location,
+               ae.seller_url, ae.seller_location,
+               ae.target_url, ae.target_location,
                ae.deal_value, ae.currency, ae.location, ae.article_date,
                ae.transaction_type, ae.log,
                ae.summary, ae.sector, ae.industry
@@ -274,7 +280,9 @@ router.post('/:id/summarize', async (req, res) => {
     const row = await db.get(
       `SELECT summary, sector, industry,
               about_acquiror, about_seller, about_target,
-              acquiror_url, seller_url, target_url
+              acquiror_url, acquiror_location,
+              seller_url, seller_location,
+              target_url, target_location
          FROM article_enrichments WHERE article_id = ?`,
       [id]
     );
@@ -287,8 +295,11 @@ router.post('/:id/summarize', async (req, res) => {
       aboutSeller: row.about_seller,
       aboutTarget: row.about_target,
       acquirorUrl: row.acquiror_url,
+      acquirorLocation: row.acquiror_location,
       sellerUrl: row.seller_url,
-      targetUrl: row.target_url
+      sellerLocation: row.seller_location,
+      targetUrl: row.target_url,
+      targetLocation: row.target_location
     });
   } catch (err) {
     console.error(err);

--- a/test/tombstone.test.js
+++ b/test/tombstone.test.js
@@ -36,3 +36,18 @@ test('omits links when URLs missing', async () => {
   const html = createTombstone(article);
   assert(!html.includes('<a'));
 });
+
+test('uses target and acquiror locations when available', async () => {
+  const { createTombstone } = await loadModule();
+  const article = {
+    acquiror: 'Acme',
+    seller: 'SellerCo',
+    target: 'Target',
+    acquiror_location: 'USA',
+    target_location: 'Canada',
+    location: 'France',
+    transaction_type: 'M&A'
+  };
+  const html = createTombstone(article);
+  assert(html.includes('Canada / USA'));
+});


### PR DESCRIPTION
## Summary
- enrich summarization prompts with acquiror, seller and target locations
- store new location fields in DB and expose them in API routes
- include party locations in tombstone display
- update tests for tombstone logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fd7fd8dbc8331a7db077287868e1d