### PR TITLE
Refine tombstone locations and add more flags

### DIFF
--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -31,7 +31,29 @@ const countryFlags = {
   'india': '🇮🇳',
   'brazil': '🇧🇷',
   'mexico': '🇲🇽',
-  'dominican republic': '🇩🇴'
+  'dominican republic': '🇩🇴',
+  'russia': '🇷🇺',
+  'south korea': '🇰🇷',
+  'korea': '🇰🇷',
+  'sweden': '🇸🇪',
+  'norway': '🇳🇴',
+  'denmark': '🇩🇰',
+  'finland': '🇫🇮',
+  'belgium': '🇧🇪',
+  'austria': '🇦🇹',
+  'ireland': '🇮🇪',
+  'portugal': '🇵🇹',
+  'poland': '🇵🇱',
+  'turkey': '🇹🇷',
+  'saudi arabia': '🇸🇦',
+  'united arab emirates': '🇦🇪',
+  'uae': '🇦🇪',
+  'south africa': '🇿🇦',
+  'new zealand': '🇳🇿',
+  'argentina': '🇦🇷',
+  'singapore': '🇸🇬',
+  'hong kong': '🇭🇰',
+  'israel': '🇮🇱'
 };
 
 function flagFromLocation(location) {
@@ -39,6 +61,12 @@ function flagFromLocation(location) {
   const parts = location.split(',');
   const country = parts[parts.length - 1].trim().toLowerCase();
   return countryFlags[country] || '';
+}
+
+function extractCountry(location) {
+  if (!location) return '';
+  const parts = location.split(',');
+  return parts[parts.length - 1].trim();
 }
 
 function formatParty(name, url) {
@@ -70,8 +98,10 @@ export function createTombstone(article) {
     ? article.transaction_type.trim()
     : '';
   const txType = txTypeRaw ? escapeHtml(txTypeRaw) : '';
-  const tLoc = article.target_location || article.targetLocation || '';
-  const aLoc = article.acquiror_location || article.acquirorLocation || '';
+  const tLocFull = article.target_location || article.targetLocation || '';
+  const aLocFull = article.acquiror_location || article.acquirorLocation || '';
+  const tLoc = extractCountry(tLocFull);
+  const aLoc = extractCountry(aLocFull);
   let location = '';
   if (tLoc && aLoc) {
     location = `${escapeHtml(tLoc)} / ${escapeHtml(aLoc)}`;
@@ -80,9 +110,9 @@ export function createTombstone(article) {
   } else if (aLoc) {
     location = escapeHtml(aLoc);
   } else if (article.location && article.location !== 'N/A') {
-    location = escapeHtml(article.location);
+    location = escapeHtml(extractCountry(article.location));
   }
-  const flag = flagFromLocation(location);
+  const flag = flagFromLocation(tLocFull || aLocFull || article.location || '');
 
   const bodyLines = [];
   if (txTypeRaw === 'M&A') {

--- a/test/tombstone.test.js
+++ b/test/tombstone.test.js
@@ -51,3 +51,26 @@ test('uses target and acquiror locations when available', async () => {
   const html = createTombstone(article);
   assert(html.includes('Canada / USA'));
 });
+
+test('strips city details from locations', async () => {
+  const { createTombstone } = await loadModule();
+  const article = {
+    acquiror_location: 'Munich, Germany',
+    target_location: 'Paris, France',
+    transaction_type: 'Other'
+  };
+  const html = createTombstone(article);
+  assert(html.includes('France / Germany'));
+  assert(!html.includes('Munich'));
+  assert(!html.includes('Paris'));
+});
+
+test('returns flags for new countries', async () => {
+  const { createTombstone } = await loadModule();
+  const article = {
+    location: 'Moscow, Russia',
+    transaction_type: 'Other'
+  };
+  const html = createTombstone(article);
+  assert(html.includes('🇷🇺'));
+});


### PR DESCRIPTION
## Summary
- show only the country in the tombstone footer
- expand the `countryFlags` map to cover more countries
- test that city details are stripped and new countries are supported

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fdcd56e1c8331ba1a26c9209fcdca