### PR TITLE
Add acquiror type classifier

### DIFF
--- a/db/init.js
+++ b/db/init.js
@@ -183,13 +183,13 @@ async function initDb() {
       'INSERT INTO prompts (name, template, fields) VALUES (?, ?, ?)',
       [
         'summarizeArticle',
-        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and include each party\'s website URL if available. Respond with JSON {"summary":"...","sector":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","acquiror_location":"...","target_url":"...","target_location":"...","seller_url":"...","seller_location":"..."}. Text: "{text}"',
-        'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,acquiror_location,target_url,target_location,seller_url,seller_location'
+        'Summarize the following article in 2-3 sentences and classify the Clairfield sector and industry. Provide a short note about the acquiror, target and seller and include each party\'s website URL if available. Classify the acquiror type as "Private equity firm", "Other financial buyer", "lender", "strategic buyer" or "N/A". Respond with JSON {"summary":"...","sector":"...","industry":"...","acquiror_type":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","acquiror_location":"...","target_url":"...","target_location":"...","seller_url":"...","seller_location":"..."}. Text: "{text}"',
+        'summary,sector,industry,acquiror_type,about_acquiror,about_target,about_seller,acquiror_url,acquiror_location,target_url,target_location,seller_url,seller_location'
       ]
     );
   } else if (!sumRow.fields) {
     await configDb.run('UPDATE prompts SET fields = ? WHERE name = ?', [
-      'summary,sector,industry,about_acquiror,about_target,about_seller,acquiror_url,acquiror_location,target_url,target_location,seller_url,seller_location',
+      'summary,sector,industry,acquiror_type,about_acquiror,about_target,about_seller,acquiror_url,acquiror_location,target_url,target_location,seller_url,seller_location',
       'summarizeArticle'
     ]);
   }
@@ -225,6 +225,7 @@ async function initDb() {
     'summary',
     'sector',
     'currency',
+    'acquiror_type',
     'about_acquiror',
     'about_seller',
     'about_target',

--- a/lib/enrichment/summarizeArticle.js
+++ b/lib/enrichment/summarizeArticle.js
@@ -3,7 +3,7 @@ const appendLog = require('./appendLog');
 const { classifySector } = require('../classifySector');
 const { markCompleted, getCompleted } = require('./steps');
 
-const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and include each party's website URL where available. Respond with JSON {"summary":"...","industry":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","acquiror_location":"...","target_url":"...","target_location":"...","seller_url":"...","seller_location":"..."}. Text: "{text}"`;
+const DEFAULT_TEMPLATE = `Summarize the following article in 2-3 sentences and classify the industry. Provide a short note about the acquiror, target and seller and include each party's website URL where available. Classify the acquiror type as "Private equity firm", "Other financial buyer", "lender", "strategic buyer" or "N/A". Respond with JSON {"summary":"...","industry":"...","acquiror_type":"...","about_acquiror":"...","about_target":"...","about_seller":"...","acquiror_url":"...","acquiror_location":"...","target_url":"...","target_location":"...","seller_url":"...","seller_location":"..."}. Text: "{text}"`;
 
 async function summarizeArticle(articleDb, configDb, openai, id, progress) {
   progress = typeof progress === 'function' ? progress : null;
@@ -23,11 +23,11 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     throw new Error('Article text not found');
   }
 
-  const { template, fields = ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'acquiror_location', 'target_url', 'target_location', 'seller_url', 'seller_location'] } = await getPrompt(
+  const { template, fields = ['summary', 'industry', 'acquiror_type', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'acquiror_location', 'target_url', 'target_location', 'seller_url', 'seller_location'] } = await getPrompt(
     configDb,
     'summarizeArticle',
     DEFAULT_TEMPLATE,
-    ['summary', 'industry', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'acquiror_location', 'target_url', 'target_location', 'seller_url', 'seller_location']
+    ['summary', 'industry', 'acquiror_type', 'about_acquiror', 'about_target', 'about_seller', 'acquiror_url', 'acquiror_location', 'target_url', 'target_location', 'seller_url', 'seller_location']
   );
   const prompt = template.replace('{text}', row.body);
 
@@ -44,6 +44,7 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
   let aboutAcquiror = '';
   let aboutSeller = '';
   let aboutTarget = '';
+  let acquirorType = 'N/A';
   let acquirorUrl = '';
   let sellerUrl = '';
   let targetUrl = '';
@@ -55,6 +56,8 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     if (parsed.summary) summary = parsed.summary;
     if (parsed.industry) industry = parsed.industry;
     aboutAcquiror = parsed.about_acquiror || parsed.aboutAcquiror || '';
+    if (parsed.acquiror_type || parsed.acquirorType)
+      acquirorType = parsed.acquiror_type || parsed.acquirorType || 'N/A';
     aboutSeller = parsed.about_seller || parsed.aboutSeller || '';
     aboutTarget = parsed.about_target || parsed.aboutTarget || '';
     acquirorUrl = parsed.acquiror_url || parsed.acquirorUrl || '';
@@ -77,16 +80,17 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
 
   await articleDb.run(
     `INSERT INTO article_enrichments (
-        article_id, summary, sector, industry,
+        article_id, summary, sector, industry, acquiror_type,
         about_acquiror, about_seller, about_target,
         acquiror_url, acquiror_location,
         seller_url, seller_location,
         target_url, target_location
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(article_id) DO UPDATE SET
          summary = excluded.summary,
          sector = excluded.sector,
          industry = excluded.industry,
+         acquiror_type = excluded.acquiror_type,
          about_acquiror = excluded.about_acquiror,
          about_seller = excluded.about_seller,
          about_target = excluded.about_target,
@@ -101,6 +105,7 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
       summary,
       sector,
       industry,
+      acquirorType,
       aboutAcquiror,
       aboutSeller,
       aboutTarget,
@@ -124,6 +129,7 @@ async function summarizeArticle(articleDb, configDb, openai, id, progress) {
     summary,
     sector,
     industry,
+    acquirorType,
     aboutAcquiror,
     aboutSeller,
     aboutTarget,

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -57,7 +57,7 @@ router.get('/mna-today', async (req, res) => {
   const query = `
     SELECT a.id, a.title, a.description, a.time, a.link,
            ae.body, ae.acquiror, ae.seller, ae.target,
-           ae.location, ae.article_date,
+           ae.acquiror_type, ae.location, ae.article_date,
            ae.transaction_type, ae.log
     FROM articles a
     JOIN article_filter_matches m ON a.id = m.article_id
@@ -108,7 +108,7 @@ router.get('/enrich-list', async (req, res) => {
            ae.acquiror_url, ae.acquiror_location,
            ae.seller_url, ae.seller_location,
            ae.target_url, ae.target_location,
-           ae.deal_value, ae.currency, ae.location, ae.article_date,
+           ae.deal_value, ae.currency, ae.acquiror_type, ae.location, ae.article_date,
            ae.transaction_type, ae.embedding, ae.log,
            ae.summary, ae.sector, ae.industry
     FROM articles a
@@ -165,7 +165,7 @@ router.get('/enriched-list', async (req, res) => {
             ae.acquiror_url, ae.acquiror_location,
             ae.seller_url, ae.seller_location,
             ae.target_url, ae.target_location,
-            ae.deal_value, ae.currency, ae.location, ae.article_date,
+            ae.deal_value, ae.currency, ae.acquiror_type, ae.location, ae.article_date,
             ae.transaction_type, ae.log,
             ae.summary, ae.sector, ae.industry
        FROM articles a
@@ -178,7 +178,7 @@ router.get('/enriched-list', async (req, res) => {
                ae.acquiror_url, ae.acquiror_location,
                ae.seller_url, ae.seller_location,
                ae.target_url, ae.target_location,
-               ae.deal_value, ae.currency, ae.location, ae.article_date,
+               ae.deal_value, ae.currency, ae.acquiror_type, ae.location, ae.article_date,
                ae.transaction_type, ae.log,
                ae.summary, ae.sector, ae.industry
       ORDER BY a.time DESC`
@@ -278,7 +278,7 @@ router.post('/:id/summarize', async (req, res) => {
   try {
     await processArticle(id, ['summary']);
     const row = await db.get(
-      `SELECT summary, sector, industry,
+      `SELECT summary, sector, industry, acquiror_type,
               about_acquiror, about_seller, about_target,
               acquiror_url, acquiror_location,
               seller_url, seller_location,
@@ -291,6 +291,7 @@ router.post('/:id/summarize', async (req, res) => {
       summary: row.summary,
       sector: row.sector,
       industry: row.industry,
+      acquirorType: row.acquiror_type,
       aboutAcquiror: row.about_acquiror,
       aboutSeller: row.about_seller,
       aboutTarget: row.about_target,


### PR DESCRIPTION
## Summary
- extend summarization prompt to classify acquiror type
- store and expose the new `acquiror_type` field
- handle schema migrations for the new column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fdef693ec8331adf686be654985b2