### PR TITLE
Add acquiror type icons to tombstone

### DIFF
--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -56,6 +56,13 @@ const countryFlags = {
   'israel': '🇮🇱'
 };
 
+export const acquirorTypeIcons = {
+  'private equity firm': '💼',
+  'other financial buyer': '💰',
+  lender: '🏦',
+  'strategic buyer': '🤝'
+};
+
 function flagFromLocation(location) {
   if (!location) return '';
   const parts = location.split(',');
@@ -98,6 +105,11 @@ export function createTombstone(article) {
     ? article.transaction_type.trim()
     : '';
   const txType = txTypeRaw ? escapeHtml(txTypeRaw) : '';
+  const acqTypeRaw = (article.acquiror_type || article.acquirorType || '').trim();
+  const acqTypeIcon =
+    acqTypeRaw && acqTypeRaw !== 'N/A'
+      ? acquirorTypeIcons[acqTypeRaw.toLowerCase()] || ''
+      : '';
   const tLocFull = article.target_location || article.targetLocation || '';
   const aLocFull = article.acquiror_location || article.acquirorLocation || '';
   const tLoc = extractCountry(tLocFull);
@@ -156,7 +168,10 @@ export function createTombstone(article) {
     }
   }
 
-  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}</div>`;
+  const iconHtml = acqTypeIcon
+    ? ` <span title="${escapeAttr(acqTypeRaw)}">${acqTypeIcon}</span>`
+    : '';
+  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}${iconHtml}</div>`;
   const footer = location
     ? `<div class="text-xs text-center w-full">${flag ? flag + ' ' : ''}${location}</div>`
     : '<div class="text-xs text-center w-full">&nbsp;</div>';


### PR DESCRIPTION
## Summary
- support icons for acquiror types
- include acquiror type icon in the tombstone header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ff0adfc548331b6f06b1d0417add3