### PR TITLE
Add acquiror type icons to tombstone

### DIFF
--- a/public/enriched.html
+++ b/public/enriched.html
@@ -68,7 +68,7 @@
       <tbody id="articlesBody"></tbody>
     </table>
     <script type="module">
-      import { createTombstone, escapeHtml } from './tombstone.js';
+      import { createTombstone, escapeHtml, acquirorTypeIcons } from './tombstone.js';
       import { sectorIcons } from './sectorIcons.js';
 
       function formatBody(text) {
@@ -110,7 +110,7 @@
       }
 
       let allArticles = [];
-      const filters = { keyword: '', sector: '', industry: '', dealValue: '' };
+      const filters = { keyword: '', sector: '', industry: '', dealValue: '', acquirorType: '' };
 
       function parseDealValueMillions(str) {
         if (!str) return null;
@@ -147,6 +147,7 @@
           if (ignore !== 'sector' && filters.sector && a.sector !== filters.sector) return false;
           if (ignore !== 'industry' && filters.industry && a.industry !== filters.industry) return false;
           if (ignore !== 'dealValue' && filters.dealValue && a.valueBucket !== filters.dealValue) return false;
+          if (ignore !== 'acquirorType' && filters.acquirorType && a.acquirorType !== filters.acquirorType) return false;
           if (kw) {
             const text = `${a.title} ${a.description || ''} ${a.body || ''}`.toLowerCase();
             if (!text.includes(kw)) return false;
@@ -205,9 +206,16 @@
           valueCounts[b] = (valueCounts[b] || 0) + 1;
         });
 
+        const typeCounts = {};
+        getRows('acquirorType').forEach(a => {
+          const t = a.acquirorType;
+          if (t && t !== 'N/A') typeCounts[t] = (typeCounts[t] || 0) + 1;
+        });
+
         const groups = {
           sector: Object.keys(sectorCounts),
           industry: Object.keys(industryCounts),
+          acquirorType: Object.keys(typeCounts),
           dealValue: ['0-20M','20-100M','100M-1B','1B+','Undisclosed'].filter(b => valueCounts[b])
         };
         Object.entries(groups).forEach(([field, values]) => {
@@ -216,8 +224,12 @@
           label.className = 'font-semibold mr-2';
           if (field === 'sector') {
             label.textContent = 'Clairfield Sector:';
+          } else if (field === 'dealValue') {
+            label.textContent = 'Deal Value:';
+          } else if (field === 'acquirorType') {
+            label.textContent = 'Acquiror Type:';
           } else {
-            label.textContent = field === 'dealValue' ? 'Deal Value:' : 'Industry:';
+            label.textContent = 'Industry:';
           }
           container.appendChild(label);
           values.slice(0, 10).forEach(v => {
@@ -229,6 +241,10 @@
             } else if (field === 'industry') {
               const count = industryCounts[v] || 0;
               pill.textContent = `${v} (${count})`;
+            } else if (field === 'acquirorType') {
+              const icon = acquirorTypeIcons[v.toLowerCase()] || '';
+              const count = typeCounts[v] || 0;
+              pill.innerHTML = `${icon} ${v} (${count})`;
             } else {
               const count = valueCounts[v] || 0;
               pill.textContent = `${v} (${count})`;
@@ -259,7 +275,11 @@
         const level = document.getElementById('levelSelect').value;
         const res = await fetch('/articles/enriched-list?level=' + level);
         const data = await res.json();
-        allArticles = data.articles.map(a => ({ ...a, valueBucket: valueBucket(a.deal_value) }));
+        allArticles = data.articles.map(a => ({
+          ...a,
+          valueBucket: valueBucket(a.deal_value),
+          acquirorType: a.acquiror_type
+        }));
         document.getElementById('stats').textContent = `Total: ${data.stats.total} | Fully Complete: ${data.stats.full} | Incomplete: ${data.stats.partial}`;
         updateSummary();
         renderArticles();

--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -116,7 +116,7 @@
       <tbody id="articlesBody"></tbody>
     </table>
     <script type="module">
-      import { createTombstone, escapeHtml } from "./tombstone.js";
+      import { createTombstone, escapeHtml, acquirorTypeIcons } from "./tombstone.js";
       import { sectorIcons } from "./sectorIcons.js";
 
       function initDatePills() {
@@ -156,6 +156,7 @@
         sector: "",
         industry: "",
         dealValue: "",
+        acquirorType: "",
         dateRange: "week",
       };
       let industryShowMore = false;
@@ -219,6 +220,12 @@
             ignore !== "dealValue" &&
             filters.dealValue &&
             a.valueBucket !== filters.dealValue
+          )
+            return false;
+          if (
+            ignore !== "acquirorType" &&
+            filters.acquirorType &&
+            a.acquirorType !== filters.acquirorType
           )
             return false;
 
@@ -299,11 +306,18 @@
           valueCounts[b] = (valueCounts[b] || 0) + 1;
         });
 
+        const typeCounts = {};
+        getRows("acquirorType").forEach((a) => {
+          const t = a.acquirorType;
+          if (t && t !== "N/A") typeCounts[t] = (typeCounts[t] || 0) + 1;
+        });
+
         const groups = {
           sector: Object.keys(sectorCounts),
           industry: Object.keys(industryCounts).sort(
             (a, b) => industryCounts[b] - industryCounts[a],
           ),
+          acquirorType: Object.keys(typeCounts),
           dealValue: [
             "0-20M",
             "20-100M",
@@ -322,9 +336,12 @@
           label.className = "font-semibold mr-2";
           if (field === "sector") {
             label.textContent = "Clairfield Sector:";
+          } else if (field === "dealValue") {
+            label.textContent = "Deal Value:";
+          } else if (field === "acquirorType") {
+            label.textContent = "Acquiror Type:";
           } else {
-            label.textContent =
-              field === "dealValue" ? "Deal Value:" : "Industry:";
+            label.textContent = "Industry:";
           }
           container.appendChild(label);
           values.forEach((v) => {
@@ -336,6 +353,10 @@
             } else if (field === "industry") {
               const count = industryCounts[v] || 0;
               pill.textContent = `${v} (${count})`;
+            } else if (field === "acquirorType") {
+              const icon = acquirorTypeIcons[v.toLowerCase()] || "";
+              const count = typeCounts[v] || 0;
+              pill.innerHTML = `${icon} ${v} (${count})`;
             } else {
               const count = valueCounts[v] || 0;
               pill.textContent = `${v} (${count})`;
@@ -403,6 +424,7 @@
         allArticles = data.articles.map((a) => ({
           ...a,
           valueBucket: valueBucket(a.deal_value),
+          acquirorType: a.acquiror_type,
         }));
         articleTotal = data.stats.total;
         updateSummary();

--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -56,6 +56,13 @@ const countryFlags = {
   'israel': '🇮🇱'
 };
 
+export const acquirorTypeIcons = {
+  'private equity firm': '💼',
+  'other financial buyer': '💰',
+  lender: '🏦',
+  'strategic buyer': '🤝'
+};
+
 function flagFromLocation(location) {
   if (!location) return '';
   const parts = location.split(',');
@@ -98,6 +105,11 @@ export function createTombstone(article) {
     ? article.transaction_type.trim()
     : '';
   const txType = txTypeRaw ? escapeHtml(txTypeRaw) : '';
+  const acqTypeRaw = (article.acquiror_type || article.acquirorType || '').trim();
+  const acqTypeIcon =
+    acqTypeRaw && acqTypeRaw !== 'N/A'
+      ? acquirorTypeIcons[acqTypeRaw.toLowerCase()] || ''
+      : '';
   const tLocFull = article.target_location || article.targetLocation || '';
   const aLocFull = article.acquiror_location || article.acquirorLocation || '';
   const tLoc = extractCountry(tLocFull);
@@ -156,7 +168,10 @@ export function createTombstone(article) {
     }
   }
 
-  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}</div>`;
+  const iconHtml = acqTypeIcon
+    ? ` <span title="${escapeAttr(acqTypeRaw)}">${acqTypeIcon}</span>`
+    : '';
+  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}${iconHtml}</div>`;
   const footer = location
     ? `<div class="text-xs text-center w-full">${flag ? flag + ' ' : ''}${location}</div>`
     : '<div class="text-xs text-center w-full">&nbsp;</div>';


### PR DESCRIPTION
## Summary
- support icons for acquiror types
- include acquiror type icon in the tombstone header
- add acquiror type filter pills on Enriched DB and This Week pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684ff0adfc548331b6f06b1d0417add3