### PR TITLE
Update buyer type display on This Week page

### DIFF
--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -107,7 +107,7 @@
           <th class="border px-2 py-1">#</th>
           <th class="border px-2 py-1">Deal</th>
           <th class="border px-2 py-1 w-1/3">Summary</th>
-          <th class="border px-2 py-1">Clairfield Sector / Industry</th>
+          <th class="border px-2 py-1">Sector/Industry/Buyer Type</th>
           <th class="border px-2 py-1">Location</th>
           <th class="border px-2 py-1">Deal Value _basecurrency</th>
           <th class="border px-2 py-1">Currency</th>
@@ -193,12 +193,27 @@
         return "1B+";
       }
 
-      function formatSectorIndustry(a) {
-        if (!a.sector && !a.industry) return "";
-        const icon = sectorIcons[a.sector] || "🏢";
-        const sector = a.sector ? escapeHtml(a.sector) : "";
-        const industry = a.industry ? escapeHtml(a.industry) : "";
-        return `${icon} ${sector}<br>${industry}`;
+      function formatSectorIndustryType(a) {
+        const parts = [];
+        if (a.sector) {
+          const icon = sectorIcons[a.sector] || "🏢";
+          parts.push(
+            `<span class="bg-gray-200 rounded-full px-2 py-1 whitespace-nowrap">${icon} ${escapeHtml(a.sector)}</span>`
+          );
+        }
+        if (a.industry) {
+          parts.push(
+            `<span class="bg-gray-200 rounded-full px-2 py-1 whitespace-nowrap">${escapeHtml(a.industry)}</span>`
+          );
+        }
+        if (a.acquirorType && a.acquirorType !== "N/A") {
+          const icon = acquirorTypeIcons[a.acquirorType.toLowerCase()] || "";
+          const label = `${icon ? icon + ' ' : ''}${escapeHtml(a.acquirorType)}`;
+          parts.push(
+            `<span class="bg-gray-200 rounded-full px-2 py-1 whitespace-nowrap">${label}</span>`
+          );
+        }
+        return parts.join(' / ');
       }
 
       function getRows(ignore, rangeOverride) {
@@ -267,7 +282,7 @@
         rows.forEach((a, idx) => {
           const tr = document.createElement("tr");
           const tombstone = createTombstone(a);
-          const sectorHtml = formatSectorIndustry(a);
+          const sectorHtml = formatSectorIndustryType(a);
           const truncated =
             a.title.length > 60 ? a.title.slice(0, 60) + "..." : a.title;
           const titleLink = `<a class="text-blue-600 underline" href="${a.link}" target="_blank">${escapeHtml(truncated)}</a>`;

--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -105,11 +105,6 @@ export function createTombstone(article) {
     ? article.transaction_type.trim()
     : '';
   const txType = txTypeRaw ? escapeHtml(txTypeRaw) : '';
-  const acqTypeRaw = (article.acquiror_type || article.acquirorType || '').trim();
-  const acqTypeIcon =
-    acqTypeRaw && acqTypeRaw !== 'N/A'
-      ? acquirorTypeIcons[acqTypeRaw.toLowerCase()] || ''
-      : '';
   const tLocFull = article.target_location || article.targetLocation || '';
   const aLocFull = article.acquiror_location || article.acquirorLocation || '';
   const tLoc = extractCountry(tLocFull);
@@ -168,10 +163,7 @@ export function createTombstone(article) {
     }
   }
 
-  const iconHtml = acqTypeIcon
-    ? ` <span title="${escapeAttr(acqTypeRaw)}">${acqTypeIcon}</span>`
-    : '';
-  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}${iconHtml}</div>`;
+  const header = `<div class="bg-gray-200 w-full text-center font-semibold text-xs">${txType || '&nbsp;'}</div>`;
   const footer = location
     ? `<div class="text-xs text-center w-full">${flag ? flag + ' ' : ''}${location}</div>`
     : '<div class="text-xs text-center w-full">&nbsp;</div>';


### PR DESCRIPTION
## Summary
- remove acquiror type icons from tombstone display
- rename sector column on `thisweek.html`
- show sector/industry/buyer type as pill items with icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68500d23c2b4833195190abc9cb79885