### PR TITLE
Use new icons and filter to M&A

### DIFF
--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -436,12 +436,14 @@
         // Use level=all to include partially enriched articles
         const res = await fetch("/articles/enriched-list?level=all");
         const data = await res.json();
-        allArticles = data.articles.map((a) => ({
-          ...a,
-          valueBucket: valueBucket(a.deal_value),
-          acquirorType: a.acquiror_type,
-        }));
-        articleTotal = data.stats.total;
+        allArticles = data.articles
+          .filter((a) => a.transaction_type === 'M&A')
+          .map((a) => ({
+            ...a,
+            valueBucket: valueBucket(a.deal_value),
+            acquirorType: a.acquiror_type,
+          }));
+        articleTotal = allArticles.length;
         updateSummary();
         renderArticles();
         updateStats();

--- a/public/tombstone.js
+++ b/public/tombstone.js
@@ -57,10 +57,10 @@ const countryFlags = {
 };
 
 export const acquirorTypeIcons = {
-  'private equity firm': '💼',
+  'private equity firm': '👔',
   'other financial buyer': '💰',
   lender: '🏦',
-  'strategic buyer': '🤝'
+  'strategic buyer': '🏭'
 };
 
 function flagFromLocation(location) {


### PR DESCRIPTION
## Summary
- switch acquiror type icons to necktie and factory
- only show M&A transactions on This Week page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850994b93d4833187816fe3337f4491