### PR TITLE
Add hourly timer log

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ async function startServer() {
   // Run the full scrape & enrich pipeline once every 24 hours
   const DAY_MS = 24 * 60 * 60 * 1000;
   setInterval(runScheduledPipeline, DAY_MS);
+
+  // Hourly log to verify timers are active
+  const HOUR_MS = 60 * 60 * 1000;
+  setInterval(() => {
+    logger.info(`Hourly timer tick at ${new Date().toISOString()}`);
+  }, HOUR_MS);
 }
 
 startServer();


### PR DESCRIPTION
## Summary
- log a message every hour so we can verify the timer is running

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850996c4f8c8331b0a3e00d86b91853