### PR TITLE
Update table layout on This Week page

### DIFF
--- a/public/thisweek.html
+++ b/public/thisweek.html
@@ -105,10 +105,10 @@
       <thead>
         <tr>
           <th class="border px-2 py-1">#</th>
-          <th class="border px-2 py-1">Deal</th>
-          <th class="border px-2 py-1 w-1/3">Summary</th>
-          <th class="border px-2 py-1">Date & Location</th>
+          <th class="border px-2 py-1" style="width: 15rem">Deal</th>
+          <th class="border px-2 py-1 w-full">Summary</th>
           <th class="border px-2 py-1">Deal Value</th>
+          <th class="border px-2 py-1">Date</th>
         </tr>
       </thead>
       <tbody id="articlesBody"></tbody>
@@ -189,6 +189,17 @@
         if (val < 100) return "20-100M";
         if (val < 1000) return "100M-1B";
         return "1B+";
+      }
+
+      function formatDate(str) {
+        if (!str) return "";
+        const d = new Date(str);
+        if (isNaN(d)) return str;
+        return d.toLocaleDateString("en-GB", {
+          day: "2-digit",
+          month: "long",
+          year: "2-digit",
+        });
       }
 
       function formatSectorIndustryType(a) {
@@ -288,13 +299,13 @@
           if (sectorHtml) summary += `<br>${sectorHtml}`;
           const currency = a.currency || extractCurrency(a.deal_value);
           const dealValue = `${a.deal_value || ""}${currency ? " " + currency : ""}`;
-          const dateLoc = `${a.article_date || ""}${a.article_date && a.location ? "<br>" : ""}${a.location || ""}`;
+          const dateText = formatDate(a.article_date);
           tr.innerHTML =
             `<td class="border px-2 py-1">${idx + 1}</td>` +
-            `<td class="border px-2 py-1">${tombstone}</td>` +
-            `<td class="border px-2 py-1 w-1/3">${summary}</td>` +
-            `<td class="border px-2 py-1">${dateLoc}</td>` +
-            `<td class="border px-2 py-1">${dealValue}</td>`;
+            `<td class="border px-2 py-1" style="width:15rem">${tombstone}</td>` +
+            `<td class="border px-2 py-1 w-full">${summary}</td>` +
+            `<td class="border px-2 py-1">${dealValue}</td>` +
+            `<td class="border px-2 py-1 whitespace-nowrap">${dateText}</td>`;
           tbody.appendChild(tr);
         });
       }


### PR DESCRIPTION
## Summary
- widen the summary column and narrow the tombstone column
- move the date column to the end and display dates in `DD MMMM YY` format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851d40c3120833185229fc705e68549